### PR TITLE
feat: Phase 2.0 CNN/RNN実装 - Issue #47対応

### DIFF
--- a/phase2/cnn.go
+++ b/phase2/cnn.go
@@ -1,0 +1,1048 @@
+// Package phase2 implements advanced neural network architectures
+// Learning Goal: Understanding specialized neural network architectures for images and sequences
+package phase2
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+)
+
+// ActivationFunction represents different activation functions for CNN layers
+type ActivationFunction int
+
+const (
+	ReLU ActivationFunction = iota
+	Sigmoid
+	Tanh
+)
+
+// PoolingType represents different pooling operations
+type PoolingType int
+
+const (
+	MaxPooling PoolingType = iota
+	AveragePooling
+)
+
+// ConvLayer represents a convolutional layer
+// Mathematical Foundation: Feature extraction through local connectivity and weight sharing
+type ConvLayer struct {
+	// Kernels: [outputChannels][inputChannels][kernelHeight][kernelWidth]
+	Kernels     [][][][]float64 // Convolution kernels/filters
+	Biases      []float64       // Bias for each output channel
+	Stride      int             // Step size for convolution
+	Padding     int             // Zero padding around input
+	Activation  ActivationFunction
+	InputShape  [3]int        // [height, width, channels]
+	OutputShape [3]int        // [height, width, channels]
+	KernelSize  int           // Assumes square kernels
+	InputCache  [][][]float64 // Cached for backpropagation
+	OutputCache [][][]float64 // Cached for backpropagation
+}
+
+// PoolingLayer represents a pooling layer for downsampling
+// Mathematical Foundation: Translation invariance and dimensionality reduction
+type PoolingLayer struct {
+	PoolSize    int           // Size of pooling window (assumes square)
+	Stride      int           // Step size for pooling
+	PoolType    PoolingType   // Max or Average pooling
+	InputShape  [3]int        // [height, width, channels]
+	OutputShape [3]int        // [height, width, channels]
+	InputCache  [][][]float64 // Cached for backpropagation
+	MaxIndices  [][][]int     // For max pooling backprop
+}
+
+// CNN represents a complete Convolutional Neural Network
+// Learning Goal: Understanding end-to-end CNN architecture
+type CNN struct {
+	ConvLayers   []*ConvLayer    // Convolutional layers for feature extraction
+	PoolLayers   []*PoolingLayer // Pooling layers for downsampling
+	FlattenShape [2]int          // [flattenedSize, outputSize]
+	FCWeights    [][]float64     // Fully connected weights
+	FCBiases     []float64       // Fully connected biases
+	LearningRate float64         // Learning rate for training
+	InputShape   [3]int          // [height, width, channels]
+	LastFeatures [][][]float64   // Cached features before flattening
+}
+
+// NewConvLayer creates a new convolutional layer with Xavier initialization
+// Learning Goal: Understanding convolution parameter initialization
+func NewConvLayer(inputChannels, outputChannels, kernelSize, stride, padding int, activation ActivationFunction) *ConvLayer {
+	conv := &ConvLayer{
+		Kernels:    make([][][][]float64, outputChannels),
+		Biases:     make([]float64, outputChannels),
+		Stride:     stride,
+		Padding:    padding,
+		Activation: activation,
+		KernelSize: kernelSize,
+	}
+
+	// Xavier initialization for convolution kernels
+	// Mathematical: variance = 2 / (fan_in + fan_out)
+	fanIn := inputChannels * kernelSize * kernelSize
+	fanOut := outputChannels * kernelSize * kernelSize
+	variance := 2.0 / float64(fanIn+fanOut)
+	stddev := math.Sqrt(variance)
+
+	for oc := 0; oc < outputChannels; oc++ {
+		conv.Kernels[oc] = make([][][]float64, inputChannels)
+		for ic := 0; ic < inputChannels; ic++ {
+			conv.Kernels[oc][ic] = make([][]float64, kernelSize)
+			for kh := 0; kh < kernelSize; kh++ {
+				conv.Kernels[oc][ic][kh] = make([]float64, kernelSize)
+				for kw := 0; kw < kernelSize; kw++ {
+					// Normal distribution initialization
+					conv.Kernels[oc][ic][kh][kw] = rand.NormFloat64() * stddev //nolint:gosec // Educational implementation, cryptographic randomness not required
+				}
+			}
+		}
+		// Small bias initialization
+		conv.Biases[oc] = 0.01
+	}
+
+	return conv
+}
+
+// NewPoolingLayer creates a new pooling layer
+func NewPoolingLayer(poolSize, stride int, poolType PoolingType) *PoolingLayer {
+	return &PoolingLayer{
+		PoolSize: poolSize,
+		Stride:   stride,
+		PoolType: poolType,
+	}
+}
+
+// NewCNN creates a new CNN with specified architecture
+// Learning Goal: Understanding CNN architecture design
+func NewCNN(inputShape [3]int, learningRate float64) *CNN {
+	return &CNN{
+		ConvLayers:   []*ConvLayer{},
+		PoolLayers:   []*PoolingLayer{},
+		LearningRate: learningRate,
+		InputShape:   inputShape,
+	}
+}
+
+// AddConvLayer adds a convolutional layer to the CNN
+func (cnn *CNN) AddConvLayer(outputChannels, kernelSize, stride, padding int, activation ActivationFunction) {
+	inputChannels := cnn.InputShape[2]
+	if len(cnn.ConvLayers) > 0 {
+		// Get channels from previous layer
+		prevLayer := cnn.ConvLayers[len(cnn.ConvLayers)-1]
+		inputChannels = prevLayer.OutputShape[2]
+	}
+
+	conv := NewConvLayer(inputChannels, outputChannels, kernelSize, stride, padding, activation)
+
+	// Calculate input shape for this layer
+	if len(cnn.ConvLayers) == 0 && len(cnn.PoolLayers) == 0 {
+		conv.InputShape = cnn.InputShape
+	} else if len(cnn.PoolLayers) > 0 {
+		// Previous layer was pooling
+		prevPool := cnn.PoolLayers[len(cnn.PoolLayers)-1]
+		conv.InputShape = prevPool.OutputShape
+	} else {
+		// Previous layer was conv
+		prevConv := cnn.ConvLayers[len(cnn.ConvLayers)-1]
+		conv.InputShape = prevConv.OutputShape
+	}
+
+	// Calculate output shape
+	outputHeight := (conv.InputShape[0]+2*padding-kernelSize)/stride + 1
+	outputWidth := (conv.InputShape[1]+2*padding-kernelSize)/stride + 1
+	conv.OutputShape = [3]int{outputHeight, outputWidth, outputChannels}
+
+	cnn.ConvLayers = append(cnn.ConvLayers, conv)
+}
+
+// AddPoolingLayer adds a pooling layer to the CNN
+func (cnn *CNN) AddPoolingLayer(poolSize, stride int, poolType PoolingType) {
+	pool := NewPoolingLayer(poolSize, stride, poolType)
+
+	// Calculate input shape for this layer
+	if len(cnn.ConvLayers) > 0 {
+		// Previous layer was conv
+		prevConv := cnn.ConvLayers[len(cnn.ConvLayers)-1]
+		pool.InputShape = prevConv.OutputShape
+	} else if len(cnn.PoolLayers) > 0 {
+		// Previous layer was pooling
+		prevPool := cnn.PoolLayers[len(cnn.PoolLayers)-1]
+		pool.InputShape = prevPool.OutputShape
+	} else {
+		pool.InputShape = cnn.InputShape
+	}
+
+	// Calculate output shape
+	outputHeight := (pool.InputShape[0]-poolSize)/stride + 1
+	outputWidth := (pool.InputShape[1]-poolSize)/stride + 1
+	pool.OutputShape = [3]int{outputHeight, outputWidth, pool.InputShape[2]}
+
+	cnn.PoolLayers = append(cnn.PoolLayers, pool)
+}
+
+// SetupFullyConnected initializes the fully connected layer
+func (cnn *CNN) SetupFullyConnected(outputSize int) error {
+	if len(cnn.ConvLayers) == 0 && len(cnn.PoolLayers) == 0 {
+		return errors.New("no conv or pool layers added")
+	}
+
+	// Get the output shape from the last layer
+	var lastShape [3]int
+	if len(cnn.PoolLayers) > 0 {
+		lastShape = cnn.PoolLayers[len(cnn.PoolLayers)-1].OutputShape
+	} else {
+		lastShape = cnn.ConvLayers[len(cnn.ConvLayers)-1].OutputShape
+	}
+
+	// Calculate flattened size
+	flattenedSize := lastShape[0] * lastShape[1] * lastShape[2]
+	cnn.FlattenShape = [2]int{flattenedSize, outputSize}
+
+	// Initialize FC weights and biases with Xavier initialization
+	fanIn := flattenedSize
+	fanOut := outputSize
+	variance := 2.0 / float64(fanIn+fanOut)
+	stddev := math.Sqrt(variance)
+
+	cnn.FCWeights = make([][]float64, outputSize)
+	cnn.FCBiases = make([]float64, outputSize)
+
+	for i := 0; i < outputSize; i++ {
+		cnn.FCWeights[i] = make([]float64, flattenedSize)
+		for j := 0; j < flattenedSize; j++ {
+			cnn.FCWeights[i][j] = rand.NormFloat64() * stddev //nolint:gosec // Educational implementation, cryptographic randomness not required
+		}
+		cnn.FCBiases[i] = 0.01
+	}
+
+	return nil
+}
+
+// Forward performs forward propagation through the CNN
+// Learning Goal: Understanding the complete CNN forward pass
+func (cnn *CNN) Forward(input [][][]float64) ([]float64, error) {
+	if len(input) != cnn.InputShape[0] || len(input[0]) != cnn.InputShape[1] || len(input[0][0]) != cnn.InputShape[2] {
+		return nil, fmt.Errorf("input shape mismatch: expected %v, got [%d][%d][%d]",
+			cnn.InputShape, len(input), len(input[0]), len(input[0][0]))
+	}
+
+	current := input
+
+	// Forward through conv and pool layers alternately
+	convIdx := 0
+	poolIdx := 0
+
+	// Determine the order of layers (simple alternating for now)
+	totalLayers := len(cnn.ConvLayers) + len(cnn.PoolLayers)
+
+	for i := 0; i < totalLayers; i++ {
+		if i%2 == 0 && convIdx < len(cnn.ConvLayers) {
+			// Conv layer
+			var err error
+			current, err = cnn.ConvLayers[convIdx].Forward(current)
+			if err != nil {
+				return nil, fmt.Errorf("conv layer %d forward failed: %w", convIdx, err)
+			}
+			convIdx++
+		} else if poolIdx < len(cnn.PoolLayers) {
+			// Pool layer
+			var err error
+			current, err = cnn.PoolLayers[poolIdx].Forward(current)
+			if err != nil {
+				return nil, fmt.Errorf("pool layer %d forward failed: %w", poolIdx, err)
+			}
+			poolIdx++
+		}
+	}
+
+	// Cache features before flattening
+	cnn.LastFeatures = current
+
+	// Flatten for fully connected layer
+	flattened := cnn.flatten(current)
+
+	// Fully connected forward pass
+	output := make([]float64, cnn.FlattenShape[1])
+	for i := 0; i < cnn.FlattenShape[1]; i++ {
+		sum := cnn.FCBiases[i]
+		for j := 0; j < len(flattened); j++ {
+			sum += cnn.FCWeights[i][j] * flattened[j]
+		}
+		// Apply softmax for classification (simplified)
+		output[i] = sum
+	}
+
+	// Apply softmax activation for final output
+	return cnn.softmax(output), nil
+}
+
+// Forward performs convolution operation for a single convolutional layer
+// Learning Goal: Understanding explicit convolution implementation
+func (conv *ConvLayer) Forward(input [][][]float64) ([][][]float64, error) {
+	// Cache input for backpropagation
+	conv.InputCache = input
+
+	inputHeight := len(input)
+	inputWidth := len(input[0])
+	inputChannels := len(input[0][0])
+
+	// Validate input channels
+	if inputChannels != len(conv.Kernels[0]) {
+		return nil, fmt.Errorf("input channels mismatch: expected %d, got %d",
+			len(conv.Kernels[0]), inputChannels)
+	}
+
+	outputChannels := len(conv.Kernels)
+	outputHeight := (inputHeight+2*conv.Padding-conv.KernelSize)/conv.Stride + 1
+	outputWidth := (inputWidth+2*conv.Padding-conv.KernelSize)/conv.Stride + 1
+
+	// Initialize output tensor
+	output := make([][][]float64, outputHeight)
+	for h := 0; h < outputHeight; h++ {
+		output[h] = make([][]float64, outputWidth)
+		for w := 0; w < outputWidth; w++ {
+			output[h][w] = make([]float64, outputChannels)
+		}
+	}
+
+	// Perform convolution for each output position
+	for h := 0; h < outputHeight; h++ {
+		for w := 0; w < outputWidth; w++ {
+			for oc := 0; oc < outputChannels; oc++ {
+				sum := conv.Biases[oc]
+
+				// Convolve with kernel
+				for kh := 0; kh < conv.KernelSize; kh++ {
+					for kw := 0; kw < conv.KernelSize; kw++ {
+						for ic := 0; ic < inputChannels; ic++ {
+							// Calculate input position with padding
+							inputH := h*conv.Stride + kh - conv.Padding
+							inputW := w*conv.Stride + kw - conv.Padding
+
+							// Check bounds (zero padding)
+							if inputH >= 0 && inputH < inputHeight &&
+								inputW >= 0 && inputW < inputWidth {
+								sum += input[inputH][inputW][ic] * conv.Kernels[oc][ic][kh][kw]
+							}
+						}
+					}
+				}
+
+				// Apply activation function
+				output[h][w][oc] = conv.activate(sum)
+			}
+		}
+	}
+
+	// Cache output for backpropagation
+	conv.OutputCache = output
+	return output, nil
+}
+
+// Forward performs pooling operation for a single pooling layer
+// Learning Goal: Understanding pooling for translation invariance
+func (pool *PoolingLayer) Forward(input [][][]float64) ([][][]float64, error) {
+	// Cache input for backpropagation
+	pool.InputCache = input
+
+	inputHeight := len(input)
+	inputWidth := len(input[0])
+	channels := len(input[0][0])
+
+	outputHeight := (inputHeight-pool.PoolSize)/pool.Stride + 1
+	outputWidth := (inputWidth-pool.PoolSize)/pool.Stride + 1
+
+	// Initialize output tensor
+	output := make([][][]float64, outputHeight)
+	pool.MaxIndices = make([][][]int, outputHeight) // For max pooling backprop
+
+	for h := 0; h < outputHeight; h++ {
+		output[h] = make([][]float64, outputWidth)
+		pool.MaxIndices[h] = make([][]int, outputWidth)
+		for w := 0; w < outputWidth; w++ {
+			output[h][w] = make([]float64, channels)
+			pool.MaxIndices[h][w] = make([]int, channels*2) // Store h,w for each channel
+		}
+	}
+
+	// Perform pooling
+	for h := 0; h < outputHeight; h++ {
+		for w := 0; w < outputWidth; w++ {
+			for c := 0; c < channels; c++ {
+				if pool.PoolType == MaxPooling {
+					maxVal := math.Inf(-1)
+					maxH, maxW := 0, 0
+
+					// Find maximum in pooling window
+					for ph := 0; ph < pool.PoolSize; ph++ {
+						for pw := 0; pw < pool.PoolSize; pw++ {
+							inputH := h*pool.Stride + ph
+							inputW := w*pool.Stride + pw
+
+							if inputH < inputHeight && inputW < inputWidth {
+								val := input[inputH][inputW][c]
+								if val > maxVal {
+									maxVal = val
+									maxH, maxW = inputH, inputW
+								}
+							}
+						}
+					}
+
+					output[h][w][c] = maxVal
+					pool.MaxIndices[h][w][c*2] = maxH
+					pool.MaxIndices[h][w][c*2+1] = maxW
+
+				} else { // AveragePooling
+					sum := 0.0
+					count := 0
+
+					// Calculate average in pooling window
+					for ph := 0; ph < pool.PoolSize; ph++ {
+						for pw := 0; pw < pool.PoolSize; pw++ {
+							inputH := h*pool.Stride + ph
+							inputW := w*pool.Stride + pw
+
+							if inputH < inputHeight && inputW < inputWidth {
+								sum += input[inputH][inputW][c]
+								count++
+							}
+						}
+					}
+
+					if count > 0 {
+						output[h][w][c] = sum / float64(count)
+					}
+				}
+			}
+		}
+	}
+
+	return output, nil
+}
+
+// activate applies the activation function
+func (conv *ConvLayer) activate(x float64) float64 {
+	switch conv.Activation {
+	case ReLU:
+		return math.Max(0, x)
+	case Sigmoid:
+		return 1.0 / (1.0 + math.Exp(-x))
+	case Tanh:
+		return math.Tanh(x)
+	default:
+		return x // Linear
+	}
+}
+
+// flatten converts 3D tensor to 1D array for fully connected layer
+func (cnn *CNN) flatten(input [][][]float64) []float64 {
+	height := len(input)
+	width := len(input[0])
+	channels := len(input[0][0])
+
+	flattened := make([]float64, height*width*channels)
+	idx := 0
+
+	for h := 0; h < height; h++ {
+		for w := 0; w < width; w++ {
+			for c := 0; c < channels; c++ {
+				flattened[idx] = input[h][w][c]
+				idx++
+			}
+		}
+	}
+
+	return flattened
+}
+
+// softmax applies softmax activation for classification
+func (cnn *CNN) softmax(input []float64) []float64 {
+	// Find max for numerical stability
+	maxVal := input[0]
+	for _, val := range input {
+		if val > maxVal {
+			maxVal = val
+		}
+	}
+
+	// Calculate softmax
+	output := make([]float64, len(input))
+	sum := 0.0
+
+	for i, val := range input {
+		output[i] = math.Exp(val - maxVal)
+		sum += output[i]
+	}
+
+	for i := range output {
+		output[i] /= sum
+	}
+
+	return output
+}
+
+// GetOutputShape returns the final output shape after all layers
+func (cnn *CNN) GetOutputShape() [2]int {
+	return cnn.FlattenShape
+}
+
+// Backward performs backpropagation through the CNN
+// Learning Goal: Understanding complete CNN training with gradient computation
+func (cnn *CNN) Backward(input [][][]float64, target []float64) error {
+	if len(target) != cnn.FlattenShape[1] {
+		return fmt.Errorf("target size mismatch: expected %d, got %d", cnn.FlattenShape[1], len(target))
+	}
+
+	// Forward pass to get activations (already cached)
+	output, err := cnn.Forward(input)
+	if err != nil {
+		return fmt.Errorf("forward pass failed: %w", err)
+	}
+
+	// Calculate output layer gradients (softmax + cross-entropy)
+	outputGradients := make([]float64, len(output))
+	for i := range output {
+		outputGradients[i] = output[i] - target[i]
+	}
+
+	// Backpropagate through fully connected layer
+	fcInputGradients, err := cnn.backwardFC(outputGradients)
+	if err != nil {
+		return fmt.Errorf("FC backward failed: %w", err)
+	}
+
+	// Unflatten gradients to 3D tensor
+	unflattenedGrads := cnn.unflatten(fcInputGradients)
+
+	// Backpropagate through conv and pool layers (reverse order)
+	currentGradients := unflattenedGrads
+
+	// Process layers in reverse order
+	totalLayers := len(cnn.ConvLayers) + len(cnn.PoolLayers)
+	convIdx := len(cnn.ConvLayers) - 1
+	poolIdx := len(cnn.PoolLayers) - 1
+
+	for i := totalLayers - 1; i >= 0; i-- {
+		if i%2 == 1 && poolIdx >= 0 {
+			// Pool layer backward
+			currentGradients, err = cnn.PoolLayers[poolIdx].Backward(currentGradients)
+			if err != nil {
+				return fmt.Errorf("pool layer %d backward failed: %w", poolIdx, err)
+			}
+			poolIdx--
+		} else if convIdx >= 0 {
+			// Conv layer backward
+			currentGradients, err = cnn.ConvLayers[convIdx].Backward(currentGradients)
+			if err != nil {
+				return fmt.Errorf("conv layer %d backward failed: %w", convIdx, err)
+			}
+			convIdx--
+		}
+	}
+
+	return nil
+}
+
+// backwardFC performs backpropagation through the fully connected layer
+func (cnn *CNN) backwardFC(outputGradients []float64) ([]float64, error) {
+	if len(outputGradients) != len(cnn.FCBiases) {
+		return nil, fmt.Errorf("output gradients size mismatch")
+	}
+
+	// Use cached features from forward pass
+	if cnn.LastFeatures == nil {
+		return nil, fmt.Errorf("forward pass must be called before backward pass")
+	}
+
+	flattenedInput := cnn.flatten(cnn.LastFeatures)
+	inputGradients := make([]float64, len(flattenedInput))
+
+	// Calculate gradients for weights and biases
+	for i := 0; i < len(cnn.FCBiases); i++ {
+		// Update bias
+		cnn.FCBiases[i] -= cnn.LearningRate * outputGradients[i]
+
+		// Update weights and calculate input gradients
+		for j := 0; j < len(flattenedInput); j++ {
+			// Weight gradient
+			weightGrad := outputGradients[i] * flattenedInput[j]
+			cnn.FCWeights[i][j] -= cnn.LearningRate * weightGrad
+
+			// Input gradient (for backprop to previous layer)
+			inputGradients[j] += outputGradients[i] * cnn.FCWeights[i][j]
+		}
+	}
+
+	return inputGradients, nil
+}
+
+// unflatten converts 1D gradients back to 3D tensor format
+func (cnn *CNN) unflatten(gradients []float64) [][][]float64 {
+	// Get the output shape from the last layer
+	var lastShape [3]int
+	if len(cnn.PoolLayers) > 0 {
+		lastShape = cnn.PoolLayers[len(cnn.PoolLayers)-1].OutputShape
+	} else {
+		lastShape = cnn.ConvLayers[len(cnn.ConvLayers)-1].OutputShape
+	}
+
+	height, width, channels := lastShape[0], lastShape[1], lastShape[2]
+	result := make([][][]float64, height)
+
+	idx := 0
+	for h := 0; h < height; h++ {
+		result[h] = make([][]float64, width)
+		for w := 0; w < width; w++ {
+			result[h][w] = make([]float64, channels)
+			for c := 0; c < channels; c++ {
+				if idx < len(gradients) {
+					result[h][w][c] = gradients[idx]
+					idx++
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// Backward performs backpropagation through a convolutional layer
+// Learning Goal: Understanding convolution gradient computation
+func (conv *ConvLayer) Backward(outputGradients [][][]float64) ([][][]float64, error) {
+	if conv.InputCache == nil || conv.OutputCache == nil {
+		return nil, fmt.Errorf("forward pass must be called before backward pass")
+	}
+
+	inputHeight := len(conv.InputCache)
+	inputWidth := len(conv.InputCache[0])
+	inputChannels := len(conv.InputCache[0][0])
+
+	outputHeight := len(outputGradients)
+	outputWidth := len(outputGradients[0])
+	outputChannels := len(outputGradients[0][0])
+
+	// Initialize input gradients
+	inputGradients := make([][][]float64, inputHeight)
+	for h := 0; h < inputHeight; h++ {
+		inputGradients[h] = make([][]float64, inputWidth)
+		for w := 0; w < inputWidth; w++ {
+			inputGradients[h][w] = make([]float64, inputChannels)
+		}
+	}
+
+	// Calculate gradients for kernels, biases, and input
+	for oc := 0; oc < outputChannels; oc++ {
+		// Bias gradient (sum of all output gradients for this channel)
+		biasGrad := 0.0
+		for h := 0; h < outputHeight; h++ {
+			for w := 0; w < outputWidth; w++ {
+				// Apply activation derivative
+				activationGrad := conv.activationDerivative(conv.OutputCache[h][w][oc])
+				grad := outputGradients[h][w][oc] * activationGrad
+				biasGrad += grad
+
+				// Update output gradients with activation derivative
+				outputGradients[h][w][oc] = grad
+			}
+		}
+
+		// Update bias
+		conv.Biases[oc] -= conv.learningRate() * biasGrad
+
+		// Calculate kernel gradients and input gradients
+		for ic := 0; ic < inputChannels; ic++ {
+			for kh := 0; kh < conv.KernelSize; kh++ {
+				for kw := 0; kw < conv.KernelSize; kw++ {
+					kernelGrad := 0.0
+
+					// Calculate kernel gradient
+					for h := 0; h < outputHeight; h++ {
+						for w := 0; w < outputWidth; w++ {
+							inputH := h*conv.Stride + kh - conv.Padding
+							inputW := w*conv.Stride + kw - conv.Padding
+
+							if inputH >= 0 && inputH < inputHeight &&
+								inputW >= 0 && inputW < inputWidth {
+								kernelGrad += outputGradients[h][w][oc] * conv.InputCache[inputH][inputW][ic]
+							}
+						}
+					}
+
+					// Update kernel weights
+					conv.Kernels[oc][ic][kh][kw] -= conv.learningRate() * kernelGrad
+				}
+			}
+		}
+
+		// Calculate input gradients
+		for h := 0; h < outputHeight; h++ {
+			for w := 0; w < outputWidth; w++ {
+				for kh := 0; kh < conv.KernelSize; kh++ {
+					for kw := 0; kw < conv.KernelSize; kw++ {
+						inputH := h*conv.Stride + kh - conv.Padding
+						inputW := w*conv.Stride + kw - conv.Padding
+
+						if inputH >= 0 && inputH < inputHeight &&
+							inputW >= 0 && inputW < inputWidth {
+							for ic := 0; ic < inputChannels; ic++ {
+								inputGradients[inputH][inputW][ic] +=
+									outputGradients[h][w][oc] * conv.Kernels[oc][ic][kh][kw]
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return inputGradients, nil
+}
+
+// Backward performs backpropagation through a pooling layer
+// Learning Goal: Understanding pooling gradient computation
+func (pool *PoolingLayer) Backward(outputGradients [][][]float64) ([][][]float64, error) {
+	if pool.InputCache == nil {
+		return nil, fmt.Errorf("forward pass must be called before backward pass")
+	}
+
+	inputHeight := len(pool.InputCache)
+	inputWidth := len(pool.InputCache[0])
+	channels := len(pool.InputCache[0][0])
+
+	outputHeight := len(outputGradients)
+	outputWidth := len(outputGradients[0])
+
+	// Initialize input gradients
+	inputGradients := make([][][]float64, inputHeight)
+	for h := 0; h < inputHeight; h++ {
+		inputGradients[h] = make([][]float64, inputWidth)
+		for w := 0; w < inputWidth; w++ {
+			inputGradients[h][w] = make([]float64, channels)
+		}
+	}
+
+	// Backpropagate gradients based on pooling type
+	for h := 0; h < outputHeight; h++ {
+		for w := 0; w < outputWidth; w++ {
+			for c := 0; c < channels; c++ {
+				if pool.PoolType == MaxPooling {
+					// For max pooling, gradient goes only to the max element
+					if c*2+1 < len(pool.MaxIndices[h][w]) {
+						maxH := pool.MaxIndices[h][w][c*2]
+						maxW := pool.MaxIndices[h][w][c*2+1]
+						if maxH < inputHeight && maxW < inputWidth {
+							inputGradients[maxH][maxW][c] += outputGradients[h][w][c]
+						}
+					}
+				} else {
+					// For average pooling, gradient is distributed evenly
+					poolGrad := outputGradients[h][w][c]
+					count := 0
+
+					// Count valid positions in pool window
+					for ph := 0; ph < pool.PoolSize; ph++ {
+						for pw := 0; pw < pool.PoolSize; pw++ {
+							inputH := h*pool.Stride + ph
+							inputW := w*pool.Stride + pw
+							if inputH < inputHeight && inputW < inputWidth {
+								count++
+							}
+						}
+					}
+
+					// Distribute gradient
+					if count > 0 {
+						avgGrad := poolGrad / float64(count)
+						for ph := 0; ph < pool.PoolSize; ph++ {
+							for pw := 0; pw < pool.PoolSize; pw++ {
+								inputH := h*pool.Stride + ph
+								inputW := w*pool.Stride + pw
+								if inputH < inputHeight && inputW < inputWidth {
+									inputGradients[inputH][inputW][c] += avgGrad
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return inputGradients, nil
+}
+
+// activationDerivative computes the derivative of the activation function
+func (conv *ConvLayer) activationDerivative(x float64) float64 {
+	switch conv.Activation {
+	case ReLU:
+		if x > 0 {
+			return 1.0
+		}
+		return 0.0
+	case Sigmoid:
+		sig := 1.0 / (1.0 + math.Exp(-x))
+		return sig * (1.0 - sig)
+	case Tanh:
+		tanh := math.Tanh(x)
+		return 1.0 - tanh*tanh
+	default:
+		return 1.0 // Linear
+	}
+}
+
+// learningRate returns the learning rate for this layer
+func (conv *ConvLayer) learningRate() float64 {
+	return 0.01 // Default learning rate, could be configurable
+}
+
+// Train trains the CNN on a single sample
+// Learning Goal: Understanding complete CNN training loop
+func (cnn *CNN) Train(input [][][]float64, target []float64) error {
+	return cnn.Backward(input, target)
+}
+
+// TrainBatch trains the CNN on a batch of samples
+func (cnn *CNN) TrainBatch(inputs [][][][]float64, targets [][]float64) error {
+	totalLoss := 0.0
+
+	for i := 0; i < len(inputs); i++ {
+		err := cnn.Train(inputs[i], targets[i])
+		if err != nil {
+			return fmt.Errorf("training sample %d failed: %w", i, err)
+		}
+
+		// Calculate loss for monitoring
+		output, err := cnn.Forward(inputs[i])
+		if err == nil {
+			for j := range output {
+				diff := output[j] - targets[i][j]
+				totalLoss += diff * diff
+			}
+		}
+	}
+
+	return nil
+}
+
+// RNNCell represents a single RNN cell
+// Mathematical Foundation: h_t = tanh(W_h * h_{t-1} + W_x * x_t + b)
+type RNNCell struct {
+	WeightsHidden [][]float64 // Hidden-to-hidden weights [hiddenSize][hiddenSize]
+	WeightsInput  [][]float64 // Input-to-hidden weights [hiddenSize][inputSize]
+	Biases        []float64   // Bias vector [hiddenSize]
+	HiddenSize    int         // Size of hidden state
+	InputSize     int         // Size of input
+	Activation    ActivationFunction
+	// Caching for backpropagation
+	InputCache  [][]float64 // Cached inputs [timesteps][inputSize]
+	HiddenCache [][]float64 // Cached hidden states [timesteps+1][hiddenSize]
+	OutputCache [][]float64 // Cached outputs [timesteps][hiddenSize]
+}
+
+// RNN represents a complete Recurrent Neural Network
+// Learning Goal: Understanding sequence processing and temporal dependencies
+type RNN struct {
+	Cell         *RNNCell    // RNN cell
+	OutputLayer  [][]float64 // Output weights [outputSize][hiddenSize]
+	OutputBias   []float64   // Output biases [outputSize]
+	OutputSize   int         // Size of output
+	LearningRate float64     // Learning rate for training
+}
+
+// NewRNNCell creates a new RNN cell with Xavier initialization
+// Learning Goal: Understanding RNN parameter initialization
+func NewRNNCell(inputSize, hiddenSize int, activation ActivationFunction) *RNNCell {
+	cell := &RNNCell{
+		WeightsHidden: make([][]float64, hiddenSize),
+		WeightsInput:  make([][]float64, hiddenSize),
+		Biases:        make([]float64, hiddenSize),
+		HiddenSize:    hiddenSize,
+		InputSize:     inputSize,
+		Activation:    activation,
+	}
+
+	// Xavier initialization for hidden-to-hidden weights
+	fanInH := hiddenSize
+	fanOutH := hiddenSize
+	varianceH := 2.0 / float64(fanInH+fanOutH)
+	stddevH := math.Sqrt(varianceH)
+
+	for i := 0; i < hiddenSize; i++ {
+		cell.WeightsHidden[i] = make([]float64, hiddenSize)
+		for j := 0; j < hiddenSize; j++ {
+			cell.WeightsHidden[i][j] = rand.NormFloat64() * stddevH //nolint:gosec // Educational implementation, cryptographic randomness not required
+		}
+	}
+
+	// Xavier initialization for input-to-hidden weights
+	fanInX := inputSize
+	fanOutX := hiddenSize
+	varianceX := 2.0 / float64(fanInX+fanOutX)
+	stddevX := math.Sqrt(varianceX)
+
+	for i := 0; i < hiddenSize; i++ {
+		cell.WeightsInput[i] = make([]float64, inputSize)
+		for j := 0; j < inputSize; j++ {
+			cell.WeightsInput[i][j] = rand.NormFloat64() * stddevX //nolint:gosec // Educational implementation, cryptographic randomness not required
+		}
+		cell.Biases[i] = 0.01 // Small bias initialization
+	}
+
+	return cell
+}
+
+// NewRNN creates a new RNN with specified architecture
+// Learning Goal: Understanding RNN architecture design
+func NewRNN(inputSize, hiddenSize, outputSize int, learningRate float64) *RNN {
+	rnn := &RNN{
+		Cell:         NewRNNCell(inputSize, hiddenSize, Tanh),
+		OutputLayer:  make([][]float64, outputSize),
+		OutputBias:   make([]float64, outputSize),
+		OutputSize:   outputSize,
+		LearningRate: learningRate,
+	}
+
+	// Initialize output layer weights
+	fanIn := hiddenSize
+	fanOut := outputSize
+	variance := 2.0 / float64(fanIn+fanOut)
+	stddev := math.Sqrt(variance)
+
+	for i := 0; i < outputSize; i++ {
+		rnn.OutputLayer[i] = make([]float64, hiddenSize)
+		for j := 0; j < hiddenSize; j++ {
+			rnn.OutputLayer[i][j] = rand.NormFloat64() * stddev //nolint:gosec // Educational implementation, cryptographic randomness not required
+		}
+		rnn.OutputBias[i] = 0.01
+	}
+
+	return rnn
+}
+
+// Forward performs forward propagation through the RNN cell for one timestep
+// Learning Goal: Understanding RNN temporal computation
+func (cell *RNNCell) Forward(input []float64, hiddenState []float64) ([]float64, error) {
+	if len(input) != cell.InputSize {
+		return nil, fmt.Errorf("input size mismatch: expected %d, got %d", cell.InputSize, len(input))
+	}
+	if len(hiddenState) != cell.HiddenSize {
+		return nil, fmt.Errorf("hidden state size mismatch: expected %d, got %d", cell.HiddenSize, len(hiddenState))
+	}
+
+	newHidden := make([]float64, cell.HiddenSize)
+
+	// Compute h_t = tanh(W_h * h_{t-1} + W_x * x_t + b)
+	for i := 0; i < cell.HiddenSize; i++ {
+		sum := cell.Biases[i]
+
+		// Add input contribution: W_x * x_t
+		for j := 0; j < cell.InputSize; j++ {
+			sum += cell.WeightsInput[i][j] * input[j]
+		}
+
+		// Add hidden contribution: W_h * h_{t-1}
+		for j := 0; j < cell.HiddenSize; j++ {
+			sum += cell.WeightsHidden[i][j] * hiddenState[j]
+		}
+
+		// Apply activation function
+		newHidden[i] = cell.activate(sum)
+	}
+
+	return newHidden, nil
+}
+
+// ForwardSequence processes a sequence through the RNN
+// Learning Goal: Understanding sequence processing in RNNs
+func (rnn *RNN) ForwardSequence(sequence [][]float64) ([][]float64, error) {
+	if len(sequence) == 0 {
+		return nil, fmt.Errorf("empty sequence")
+	}
+
+	sequenceLength := len(sequence)
+	hiddenStates := make([][]float64, sequenceLength+1)
+	outputs := make([][]float64, sequenceLength)
+
+	// Initialize hidden state to zeros
+	hiddenStates[0] = make([]float64, rnn.Cell.HiddenSize)
+
+	// Cache inputs and states for backpropagation
+	rnn.Cell.InputCache = make([][]float64, sequenceLength)
+	rnn.Cell.HiddenCache = make([][]float64, sequenceLength+1)
+	rnn.Cell.OutputCache = make([][]float64, sequenceLength)
+
+	// Process each timestep
+	for t := 0; t < sequenceLength; t++ {
+		// Cache input and previous hidden state
+		rnn.Cell.InputCache[t] = make([]float64, len(sequence[t]))
+		copy(rnn.Cell.InputCache[t], sequence[t])
+
+		rnn.Cell.HiddenCache[t] = make([]float64, len(hiddenStates[t]))
+		copy(rnn.Cell.HiddenCache[t], hiddenStates[t])
+
+		// Forward through RNN cell
+		nextHidden, err := rnn.Cell.Forward(sequence[t], hiddenStates[t])
+		if err != nil {
+			return nil, fmt.Errorf("RNN cell forward failed at timestep %d: %w", t, err)
+		}
+		hiddenStates[t+1] = nextHidden
+
+		// Compute output from hidden state
+		output := make([]float64, rnn.OutputSize)
+		for i := 0; i < rnn.OutputSize; i++ {
+			sum := rnn.OutputBias[i]
+			for j := 0; j < rnn.Cell.HiddenSize; j++ {
+				sum += rnn.OutputLayer[i][j] * nextHidden[j]
+			}
+			output[i] = sum // No activation for output layer (can be added later)
+		}
+		outputs[t] = output
+
+		// Cache hidden state and output
+		rnn.Cell.HiddenCache[t+1] = make([]float64, len(nextHidden))
+		copy(rnn.Cell.HiddenCache[t+1], nextHidden)
+
+		rnn.Cell.OutputCache[t] = make([]float64, len(output))
+		copy(rnn.Cell.OutputCache[t], output)
+	}
+
+	return outputs, nil
+}
+
+// activate applies the activation function for RNN cell
+func (cell *RNNCell) activate(x float64) float64 {
+	switch cell.Activation {
+	case ReLU:
+		return math.Max(0, x)
+	case Sigmoid:
+		return 1.0 / (1.0 + math.Exp(-x))
+	case Tanh:
+		return math.Tanh(x)
+	default:
+		return x // Linear
+	}
+}
+
+// activateDerivative computes the derivative of the activation function for RNN
+//
+//nolint:unused // Prepared for future RNN backpropagation implementation
+func (cell *RNNCell) activateDerivative(x float64) float64 {
+	switch cell.Activation {
+	case ReLU:
+		if x > 0 {
+			return 1.0
+		}
+		return 0.0
+	case Sigmoid:
+		sig := 1.0 / (1.0 + math.Exp(-x))
+		return sig * (1.0 - sig)
+	case Tanh:
+		tanh := math.Tanh(x)
+		return 1.0 - tanh*tanh
+	default:
+		return 1.0 // Linear
+	}
+}

--- a/phase2/cnn_test.go
+++ b/phase2/cnn_test.go
@@ -1,0 +1,1014 @@
+package phase2
+
+import (
+	"math"
+	"testing"
+)
+
+// TestConvLayerCreation tests basic convolutional layer creation
+func TestConvLayerCreation(t *testing.T) {
+	t.Run("BasicCreation", func(t *testing.T) {
+		conv := NewConvLayer(3, 16, 3, 1, 1, ReLU)
+
+		if len(conv.Kernels) != 16 {
+			t.Errorf("Expected 16 output channels, got %d", len(conv.Kernels))
+		}
+
+		if len(conv.Kernels[0]) != 3 {
+			t.Errorf("Expected 3 input channels, got %d", len(conv.Kernels[0]))
+		}
+
+		if len(conv.Kernels[0][0]) != 3 || len(conv.Kernels[0][0][0]) != 3 {
+			t.Errorf("Expected 3x3 kernel, got %dx%d", len(conv.Kernels[0][0]), len(conv.Kernels[0][0][0]))
+		}
+
+		if len(conv.Biases) != 16 {
+			t.Errorf("Expected 16 biases, got %d", len(conv.Biases))
+		}
+	})
+
+	t.Run("ParameterInitialization", func(t *testing.T) {
+		conv := NewConvLayer(1, 1, 3, 1, 0, ReLU)
+
+		// Check that weights are not all zero (should be randomly initialized)
+		nonZeroCount := 0
+		for oc := 0; oc < len(conv.Kernels); oc++ {
+			for ic := 0; ic < len(conv.Kernels[oc]); ic++ {
+				for kh := 0; kh < len(conv.Kernels[oc][ic]); kh++ {
+					for kw := 0; kw < len(conv.Kernels[oc][ic][kh]); kw++ {
+						if conv.Kernels[oc][ic][kh][kw] != 0 {
+							nonZeroCount++
+						}
+					}
+				}
+			}
+		}
+
+		if nonZeroCount == 0 {
+			t.Error("All kernel weights are zero - initialization failed")
+		}
+	})
+}
+
+// TestConvLayerForward tests convolution forward propagation
+func TestConvLayerForward(t *testing.T) {
+	t.Run("SimpleConvolution", func(t *testing.T) {
+		// Create a simple 1-channel input
+		input := [][][]float64{
+			{{1}, {2}, {3}},
+			{{4}, {5}, {6}},
+			{{7}, {8}, {9}},
+		}
+
+		// Create conv layer with 1 output channel, 3x3 kernel, no padding
+		conv := NewConvLayer(1, 1, 3, 1, 0, ReLU)
+
+		// Set known kernel values for testing
+		conv.Kernels[0][0] = [][]float64{
+			{1, 0, -1},
+			{1, 0, -1},
+			{1, 0, -1},
+		}
+		conv.Biases[0] = 0
+
+		output, err := conv.Forward(input)
+		if err != nil {
+			t.Fatalf("Forward pass failed: %v", err)
+		}
+
+		// Expected output shape: 1x1x1 (3x3 input with 3x3 kernel, no padding)
+		if len(output) != 1 || len(output[0]) != 1 || len(output[0][0]) != 1 {
+			t.Errorf("Expected output shape [1][1][1], got [%d][%d][%d]",
+				len(output), len(output[0]), len(output[0][0]))
+		}
+
+		// The convolution should apply edge detection (vertical lines)
+		expectedSum := float64(1*1 + 2*0 + 3*(-1) + 4*1 + 5*0 + 6*(-1) + 7*1 + 8*0 + 9*(-1))
+		expected := math.Max(0, expectedSum) // ReLU activation
+
+		if math.Abs(output[0][0][0]-expected) > 1e-6 {
+			t.Errorf("Expected output %f, got %f", expected, output[0][0][0])
+		}
+	})
+
+	t.Run("ConvolutionWithPadding", func(t *testing.T) {
+		// Create a 2x2 input
+		input := [][][]float64{
+			{{1}, {2}},
+			{{3}, {4}},
+		}
+
+		// Conv layer with padding=1 should maintain size
+		conv := NewConvLayer(1, 1, 3, 1, 1, ReLU)
+		conv.Kernels[0][0] = [][]float64{
+			{1, 1, 1},
+			{1, 1, 1},
+			{1, 1, 1},
+		}
+		conv.Biases[0] = 0
+
+		output, err := conv.Forward(input)
+		if err != nil {
+			t.Fatalf("Forward pass failed: %v", err)
+		}
+
+		// With padding=1, output should be same size as input
+		if len(output) != 2 || len(output[0]) != 2 {
+			t.Errorf("Expected output shape [2][2][1], got [%d][%d][%d]",
+				len(output), len(output[0]), len(output[0][0]))
+		}
+	})
+
+	t.Run("MultiChannelConvolution", func(t *testing.T) {
+		// Create RGB-like input (3 channels)
+		input := [][][]float64{
+			{{1, 2, 3}, {4, 5, 6}},
+			{{7, 8, 9}, {10, 11, 12}},
+		}
+
+		// Conv layer: 3 input channels -> 2 output channels
+		conv := NewConvLayer(3, 2, 2, 1, 0, ReLU)
+
+		// Set known kernel values
+		for oc := 0; oc < 2; oc++ {
+			for ic := 0; ic < 3; ic++ {
+				conv.Kernels[oc][ic] = [][]float64{
+					{1, 0},
+					{0, 1},
+				}
+			}
+			conv.Biases[oc] = 0
+		}
+
+		output, err := conv.Forward(input)
+		if err != nil {
+			t.Fatalf("Forward pass failed: %v", err)
+		}
+
+		// Expected output shape: 1x1x2 (2x2 input with 2x2 kernel, no padding)
+		if len(output) != 1 || len(output[0]) != 1 || len(output[0][0]) != 2 {
+			t.Errorf("Expected output shape [1][1][2], got [%d][%d][%d]",
+				len(output), len(output[0]), len(output[0][0]))
+		}
+	})
+}
+
+// TestActivationFunctions tests different activation functions
+func TestActivationFunctions(t *testing.T) {
+	testCases := []struct {
+		activation ActivationFunction
+		input      float64
+		expected   float64
+		tolerance  float64
+	}{
+		{ReLU, 5.0, 5.0, 1e-6},
+		{ReLU, -3.0, 0.0, 1e-6},
+		{ReLU, 0.0, 0.0, 1e-6},
+		{Sigmoid, 0.0, 0.5, 1e-6},
+		{Sigmoid, 100.0, 1.0, 1e-3},  // Large positive should approach 1
+		{Sigmoid, -100.0, 0.0, 1e-3}, // Large negative should approach 0
+		{Tanh, 0.0, 0.0, 1e-6},
+		{Tanh, 100.0, 1.0, 1e-3},
+		{Tanh, -100.0, -1.0, 1e-3},
+	}
+
+	for _, tc := range testCases {
+		conv := &ConvLayer{Activation: tc.activation}
+		result := conv.activate(tc.input)
+
+		if math.Abs(result-tc.expected) > tc.tolerance {
+			t.Errorf("Activation %v with input %f: expected %f, got %f",
+				tc.activation, tc.input, tc.expected, result)
+		}
+	}
+}
+
+// TestPoolingLayer tests pooling operations
+func TestPoolingLayer(t *testing.T) {
+	t.Run("MaxPooling", func(t *testing.T) {
+		// Create 4x4 input
+		input := [][][]float64{
+			{{1}, {3}, {2}, {4}},
+			{{5}, {7}, {6}, {8}},
+			{{9}, {11}, {10}, {12}},
+			{{13}, {15}, {14}, {16}},
+		}
+
+		pool := NewPoolingLayer(2, 2, MaxPooling)
+
+		output, err := pool.Forward(input)
+		if err != nil {
+			t.Fatalf("Pooling forward failed: %v", err)
+		}
+
+		// Expected output: 2x2 (4x4 input with 2x2 pool, stride 2)
+		if len(output) != 2 || len(output[0]) != 2 || len(output[0][0]) != 1 {
+			t.Errorf("Expected output shape [2][2][1], got [%d][%d][%d]",
+				len(output), len(output[0]), len(output[0][0]))
+		}
+
+		// Check max pooling results
+		expected := [][][]float64{
+			{{7}, {8}},
+			{{15}, {16}},
+		}
+
+		for h := 0; h < 2; h++ {
+			for w := 0; w < 2; w++ {
+				if output[h][w][0] != expected[h][w][0] {
+					t.Errorf("At position [%d][%d][0]: expected %f, got %f",
+						h, w, expected[h][w][0], output[h][w][0])
+				}
+			}
+		}
+	})
+
+	t.Run("AveragePooling", func(t *testing.T) {
+		// Create 2x2 input with known values
+		input := [][][]float64{
+			{{1}, {3}},
+			{{2}, {4}},
+		}
+
+		pool := NewPoolingLayer(2, 1, AveragePooling)
+
+		output, err := pool.Forward(input)
+		if err != nil {
+			t.Fatalf("Pooling forward failed: %v", err)
+		}
+
+		// Expected: average of all 4 values = (1+3+2+4)/4 = 2.5
+		expected := 2.5
+		if math.Abs(output[0][0][0]-expected) > 1e-6 {
+			t.Errorf("Expected %f, got %f", expected, output[0][0][0])
+		}
+	})
+}
+
+// TestCNNArchitecture tests complete CNN forward pass
+func TestCNNArchitecture(t *testing.T) {
+	t.Run("SimpleCNNForward", func(t *testing.T) {
+		// Create a simple CNN: Conv -> Pool -> FC
+		cnn := NewCNN([3]int{4, 4, 1}, 0.01)
+
+		// Add conv layer: 1 input channel -> 2 output channels
+		cnn.AddConvLayer(2, 3, 1, 1, ReLU)
+
+		// Add pooling layer
+		cnn.AddPoolingLayer(2, 2, MaxPooling)
+
+		// Setup fully connected layer for 2 classes
+		err := cnn.SetupFullyConnected(2)
+		if err != nil {
+			t.Fatalf("Failed to setup FC layer: %v", err)
+		}
+
+		// Create test input
+		input := [][][]float64{
+			{{1}, {2}, {3}, {4}},
+			{{5}, {6}, {7}, {8}},
+			{{9}, {10}, {11}, {12}},
+			{{13}, {14}, {15}, {16}},
+		}
+
+		output, err := cnn.Forward(input)
+		if err != nil {
+			t.Fatalf("CNN forward failed: %v", err)
+		}
+
+		// Check output dimensions
+		if len(output) != 2 {
+			t.Errorf("Expected 2 output classes, got %d", len(output))
+		}
+
+		// Check softmax normalization (sum should be approximately 1)
+		sum := 0.0
+		for _, val := range output {
+			sum += val
+		}
+
+		if math.Abs(sum-1.0) > 1e-6 {
+			t.Errorf("Softmax output sum should be 1.0, got %f", sum)
+		}
+
+		// All outputs should be non-negative (softmax property)
+		for i, val := range output {
+			if val < 0 {
+				t.Errorf("Output[%d] should be non-negative, got %f", i, val)
+			}
+		}
+	})
+
+	t.Run("CNNShapeCalculation", func(t *testing.T) {
+		cnn := NewCNN([3]int{28, 28, 1}, 0.01) // MNIST-like input
+
+		// Conv layer: 28x28x1 -> 26x26x32 (3x3 kernel, no padding)
+		cnn.AddConvLayer(32, 3, 1, 0, ReLU)
+
+		// Pool layer: 26x26x32 -> 13x13x32 (2x2 pool, stride 2)
+		cnn.AddPoolingLayer(2, 2, MaxPooling)
+
+		// Conv layer: 13x13x32 -> 11x11x64 (3x3 kernel, no padding)
+		cnn.AddConvLayer(64, 3, 1, 0, ReLU)
+
+		// Pool layer: 11x11x64 -> 5x5x64 (2x2 pool, stride 2)
+		cnn.AddPoolingLayer(2, 2, MaxPooling)
+
+		err := cnn.SetupFullyConnected(10)
+		if err != nil {
+			t.Fatalf("Failed to setup FC layer: %v", err)
+		}
+
+		expectedFlattenSize := 5 * 5 * 64 // 1600
+		if cnn.FlattenShape[0] != expectedFlattenSize {
+			t.Errorf("Expected flattened size %d, got %d", expectedFlattenSize, cnn.FlattenShape[0])
+		}
+
+		if cnn.FlattenShape[1] != 10 {
+			t.Errorf("Expected 10 output classes, got %d", cnn.FlattenShape[1])
+		}
+	})
+}
+
+// TestCNNEdgeCases tests edge cases and error conditions
+func TestCNNEdgeCases(t *testing.T) {
+	t.Run("InvalidInputShape", func(t *testing.T) {
+		cnn := NewCNN([3]int{4, 4, 1}, 0.01)
+		cnn.AddConvLayer(2, 3, 1, 1, ReLU)
+		cnn.SetupFullyConnected(2)
+
+		// Wrong input shape
+		invalidInput := [][][]float64{
+			{{1}, {2}}, // 2x2 instead of 4x4
+			{{3}, {4}},
+		}
+
+		_, err := cnn.Forward(invalidInput)
+		if err == nil {
+			t.Error("Expected error for invalid input shape")
+		}
+	})
+
+	t.Run("NoLayersError", func(t *testing.T) {
+		cnn := NewCNN([3]int{4, 4, 1}, 0.01)
+
+		err := cnn.SetupFullyConnected(2)
+		if err == nil {
+			t.Error("Expected error when setting up FC layer without conv/pool layers")
+		}
+	})
+
+	t.Run("ChannelMismatch", func(t *testing.T) {
+		conv := NewConvLayer(3, 1, 3, 1, 0, ReLU)
+
+		// Input with wrong number of channels
+		input := [][][]float64{
+			{{1}, {2}}, // 1 channel instead of 3
+			{{3}, {4}},
+		}
+
+		_, err := conv.Forward(input)
+		if err == nil {
+			t.Error("Expected error for channel mismatch")
+		}
+	})
+}
+
+// TestSoftmaxFunction tests the softmax implementation
+func TestSoftmaxFunction(t *testing.T) {
+	cnn := &CNN{}
+
+	t.Run("BasicSoftmax", func(t *testing.T) {
+		input := []float64{1.0, 2.0, 3.0}
+		output := cnn.softmax(input)
+
+		// Check sum equals 1
+		sum := 0.0
+		for _, val := range output {
+			sum += val
+		}
+
+		if math.Abs(sum-1.0) > 1e-6 {
+			t.Errorf("Softmax sum should be 1.0, got %f", sum)
+		}
+
+		// Check all values are positive
+		for i, val := range output {
+			if val <= 0 {
+				t.Errorf("Softmax output[%d] should be positive, got %f", i, val)
+			}
+		}
+
+		// Check that larger inputs get larger outputs
+		if output[2] <= output[1] || output[1] <= output[0] {
+			t.Error("Softmax should preserve ordering")
+		}
+	})
+
+	t.Run("NumericalStability", func(t *testing.T) {
+		// Test with large values that could cause overflow
+		input := []float64{1000.0, 1001.0, 1002.0}
+		output := cnn.softmax(input)
+
+		// Should not contain NaN or Inf
+		for i, val := range output {
+			if math.IsNaN(val) || math.IsInf(val, 0) {
+				t.Errorf("Softmax output[%d] is not finite: %f", i, val)
+			}
+		}
+
+		// Sum should still be 1
+		sum := 0.0
+		for _, val := range output {
+			sum += val
+		}
+
+		if math.Abs(sum-1.0) > 1e-6 {
+			t.Errorf("Softmax sum should be 1.0 even with large inputs, got %f", sum)
+		}
+	})
+}
+
+// TestCNNBackpropagation tests CNN training functionality
+func TestCNNBackpropagation(t *testing.T) {
+	t.Run("BasicTraining", func(t *testing.T) {
+		// Create a simple CNN for binary classification
+		cnn := NewCNN([3]int{4, 4, 1}, 0.1)
+		cnn.AddConvLayer(2, 3, 1, 1, ReLU)
+		cnn.AddPoolingLayer(2, 2, MaxPooling)
+		err := cnn.SetupFullyConnected(2)
+		if err != nil {
+			t.Fatalf("Failed to setup CNN: %v", err)
+		}
+
+		// Create simple training data
+		input := [][][]float64{
+			{{1}, {0}, {1}, {0}},
+			{{0}, {1}, {0}, {1}},
+			{{1}, {0}, {1}, {0}},
+			{{0}, {1}, {0}, {1}},
+		}
+		target := []float64{1.0, 0.0} // Binary target
+
+		// Test single training step
+		err = cnn.Train(input, target)
+		if err != nil {
+			t.Fatalf("Training failed: %v", err)
+		}
+
+		// Verify that forward pass still works after training
+		output, err := cnn.Forward(input)
+		if err != nil {
+			t.Fatalf("Forward pass failed after training: %v", err)
+		}
+
+		// Check output properties
+		if len(output) != 2 {
+			t.Errorf("Expected 2 outputs, got %d", len(output))
+		}
+
+		// Check softmax normalization
+		sum := 0.0
+		for _, val := range output {
+			sum += val
+		}
+		if math.Abs(sum-1.0) > 1e-6 {
+			t.Errorf("Output sum should be 1.0, got %f", sum)
+		}
+	})
+
+	t.Run("MultipleTrainingSteps", func(t *testing.T) {
+		cnn := NewCNN([3]int{2, 2, 1}, 0.1)
+		cnn.AddConvLayer(1, 2, 1, 0, ReLU)
+		err := cnn.SetupFullyConnected(2)
+		if err != nil {
+			t.Fatalf("Failed to setup CNN: %v", err)
+		}
+
+		// Simple checkerboard pattern
+		input := [][][]float64{
+			{{1}, {0}},
+			{{0}, {1}},
+		}
+		target := []float64{1.0, 0.0}
+
+		// Get initial output
+		initialOutput, err := cnn.Forward(input)
+		if err != nil {
+			t.Fatalf("Initial forward pass failed: %v", err)
+		}
+
+		// Train for multiple steps
+		for i := 0; i < 10; i++ {
+			err = cnn.Train(input, target)
+			if err != nil {
+				t.Fatalf("Training step %d failed: %v", i, err)
+			}
+		}
+
+		// Get final output
+		finalOutput, err := cnn.Forward(input)
+		if err != nil {
+			t.Fatalf("Final forward pass failed: %v", err)
+		}
+
+		// Check that output has changed (learning occurred)
+		changed := false
+		for i := range initialOutput {
+			if math.Abs(initialOutput[i]-finalOutput[i]) > 1e-6 {
+				changed = true
+				break
+			}
+		}
+		if !changed {
+			t.Error("Output should change after training")
+		}
+	})
+
+	t.Run("BatchTraining", func(t *testing.T) {
+		cnn := NewCNN([3]int{2, 2, 1}, 0.05)
+		cnn.AddConvLayer(1, 2, 1, 0, ReLU)
+		err := cnn.SetupFullyConnected(2)
+		if err != nil {
+			t.Fatalf("Failed to setup CNN: %v", err)
+		}
+
+		// Create batch of 2 samples
+		inputs := [][][][]float64{
+			{{{1}, {0}}, {{0}, {1}}}, // Sample 1
+			{{{0}, {1}}, {{1}, {0}}}, // Sample 2
+		}
+		targets := [][]float64{
+			{1.0, 0.0}, // Target 1
+			{0.0, 1.0}, // Target 2
+		}
+
+		err = cnn.TrainBatch(inputs, targets)
+		if err != nil {
+			t.Fatalf("Batch training failed: %v", err)
+		}
+
+		// Verify both samples can be processed
+		for i := range inputs {
+			output, err := cnn.Forward(inputs[i])
+			if err != nil {
+				t.Fatalf("Forward pass failed for sample %d: %v", i, err)
+			}
+			if len(output) != 2 {
+				t.Errorf("Expected 2 outputs for sample %d, got %d", i, len(output))
+			}
+		}
+	})
+}
+
+// TestActivationDerivatives tests activation function derivatives
+func TestActivationDerivatives(t *testing.T) {
+	conv := &ConvLayer{Activation: ReLU}
+
+	testCases := []struct {
+		activation ActivationFunction
+		input      float64
+		expected   float64
+		tolerance  float64
+	}{
+		{ReLU, 5.0, 1.0, 1e-6},
+		{ReLU, -3.0, 0.0, 1e-6},
+		{ReLU, 0.0, 0.0, 1e-6},
+		{Sigmoid, 0.0, 0.25, 1e-6}, // sigmoid'(0) = 0.5 * 0.5 = 0.25
+		{Tanh, 0.0, 1.0, 1e-6},     // tanh'(0) = 1 - 0^2 = 1
+	}
+
+	for _, tc := range testCases {
+		conv.Activation = tc.activation
+		result := conv.activationDerivative(tc.input)
+
+		if math.Abs(result-tc.expected) > tc.tolerance {
+			t.Errorf("Activation derivative %v with input %f: expected %f, got %f",
+				tc.activation, tc.input, tc.expected, result)
+		}
+	}
+}
+
+// TestGradientFlow tests that gradients flow correctly through the network
+func TestGradientFlow(t *testing.T) {
+	t.Run("ConvLayerGradients", func(t *testing.T) {
+		conv := NewConvLayer(1, 1, 2, 1, 0, ReLU)
+
+		// Simple 2x2 input
+		input := [][][]float64{
+			{{1}, {2}},
+			{{3}, {4}},
+		}
+
+		// Forward pass
+		_, err := conv.Forward(input)
+		if err != nil {
+			t.Fatalf("Forward pass failed: %v", err)
+		}
+
+		// Simple gradient
+		outputGrads := [][][]float64{
+			{{1}}, // Single output gradient
+		}
+
+		// Backward pass
+		inputGrads, err := conv.Backward(outputGrads)
+		if err != nil {
+			t.Fatalf("Backward pass failed: %v", err)
+		}
+
+		// Check that input gradients have correct shape
+		if len(inputGrads) != 2 || len(inputGrads[0]) != 2 || len(inputGrads[0][0]) != 1 {
+			t.Errorf("Input gradients shape mismatch: got [%d][%d][%d], expected [2][2][1]",
+				len(inputGrads), len(inputGrads[0]), len(inputGrads[0][0]))
+		}
+	})
+
+	t.Run("PoolLayerGradients", func(t *testing.T) {
+		pool := NewPoolingLayer(2, 2, MaxPooling)
+
+		// 4x4 input
+		input := [][][]float64{
+			{{1}, {3}, {2}, {4}},
+			{{5}, {7}, {6}, {8}},
+			{{9}, {11}, {10}, {12}},
+			{{13}, {15}, {14}, {16}},
+		}
+
+		// Forward pass
+		_, err := pool.Forward(input)
+		if err != nil {
+			t.Fatalf("Pooling forward failed: %v", err)
+		}
+
+		// Output gradients
+		outputGrads := [][][]float64{
+			{{1}, {1}},
+			{{1}, {1}},
+		}
+
+		// Backward pass
+		inputGrads, err := pool.Backward(outputGrads)
+		if err != nil {
+			t.Fatalf("Pooling backward failed: %v", err)
+		}
+
+		// Check input gradients shape
+		if len(inputGrads) != 4 || len(inputGrads[0]) != 4 || len(inputGrads[0][0]) != 1 {
+			t.Errorf("Input gradients shape mismatch: got [%d][%d][%d], expected [4][4][1]",
+				len(inputGrads), len(inputGrads[0]), len(inputGrads[0][0]))
+		}
+
+		// For max pooling, only max positions should have non-zero gradients
+		nonZeroCount := 0
+		for h := 0; h < 4; h++ {
+			for w := 0; w < 4; w++ {
+				if inputGrads[h][w][0] != 0 {
+					nonZeroCount++
+				}
+			}
+		}
+
+		// Should have exactly 4 non-zero gradients (one per 2x2 pool window)
+		if nonZeroCount != 4 {
+			t.Errorf("Expected 4 non-zero gradients for max pooling, got %d", nonZeroCount)
+		}
+	})
+}
+
+// TestCNNLearning tests that the CNN can learn a simple pattern
+func TestCNNLearning(t *testing.T) {
+	t.Run("SimplePatternLearning", func(t *testing.T) {
+		// Create CNN for binary classification
+		cnn := NewCNN([3]int{3, 3, 1}, 0.1)
+		cnn.AddConvLayer(2, 2, 1, 0, ReLU)
+		err := cnn.SetupFullyConnected(2)
+		if err != nil {
+			t.Fatalf("Failed to setup CNN: %v", err)
+		}
+
+		// Define simple patterns
+		pattern1 := [][][]float64{ // Diagonal pattern -> class 0
+			{{1}, {0}, {0}},
+			{{0}, {1}, {0}},
+			{{0}, {0}, {1}},
+		}
+		target1 := []float64{1.0, 0.0}
+
+		pattern2 := [][][]float64{ // Anti-diagonal pattern -> class 1
+			{{0}, {0}, {1}},
+			{{0}, {1}, {0}},
+			{{1}, {0}, {0}},
+		}
+		target2 := []float64{0.0, 1.0}
+
+		// Get initial predictions
+		initialPred1, _ := cnn.Forward(pattern1)
+		initialPred2, _ := cnn.Forward(pattern2)
+
+		// Train for multiple epochs
+		for epoch := 0; epoch < 20; epoch++ {
+			err = cnn.Train(pattern1, target1)
+			if err != nil {
+				t.Fatalf("Training pattern 1 failed: %v", err)
+			}
+
+			err = cnn.Train(pattern2, target2)
+			if err != nil {
+				t.Fatalf("Training pattern 2 failed: %v", err)
+			}
+		}
+
+		// Get final predictions
+		finalPred1, _ := cnn.Forward(pattern1)
+		finalPred2, _ := cnn.Forward(pattern2)
+
+		// Check that predictions moved in the right direction
+		// Pattern 1 should increase confidence in class 0 (index 0)
+		if finalPred1[0] <= initialPred1[0] {
+			t.Error("Pattern 1 should increase confidence in class 0")
+		}
+
+		// Pattern 2 should increase confidence in class 1 (index 1)
+		if finalPred2[1] <= initialPred2[1] {
+			t.Error("Pattern 2 should increase confidence in class 1")
+		}
+	})
+}
+
+// TestRNNCell tests basic RNN cell functionality
+func TestRNNCell(t *testing.T) {
+	t.Run("CellCreation", func(t *testing.T) {
+		cell := NewRNNCell(3, 4, Tanh)
+
+		if cell.InputSize != 3 {
+			t.Errorf("Expected input size 3, got %d", cell.InputSize)
+		}
+		if cell.HiddenSize != 4 {
+			t.Errorf("Expected hidden size 4, got %d", cell.HiddenSize)
+		}
+		if len(cell.WeightsInput) != 4 {
+			t.Errorf("Expected 4 input weight rows, got %d", len(cell.WeightsInput))
+		}
+		if len(cell.WeightsInput[0]) != 3 {
+			t.Errorf("Expected 3 input weight columns, got %d", len(cell.WeightsInput[0]))
+		}
+		if len(cell.WeightsHidden) != 4 {
+			t.Errorf("Expected 4 hidden weight rows, got %d", len(cell.WeightsHidden))
+		}
+		if len(cell.WeightsHidden[0]) != 4 {
+			t.Errorf("Expected 4 hidden weight columns, got %d", len(cell.WeightsHidden[0]))
+		}
+		if len(cell.Biases) != 4 {
+			t.Errorf("Expected 4 biases, got %d", len(cell.Biases))
+		}
+	})
+
+	t.Run("SingleTimestepForward", func(t *testing.T) {
+		cell := NewRNNCell(2, 3, Tanh)
+
+		// Set known weights for testing
+		for i := 0; i < 3; i++ {
+			for j := 0; j < 2; j++ {
+				cell.WeightsInput[i][j] = 0.1
+			}
+			for j := 0; j < 3; j++ {
+				cell.WeightsHidden[i][j] = 0.1
+			}
+			cell.Biases[i] = 0.0
+		}
+
+		input := []float64{1.0, 0.5}
+		hiddenState := []float64{0.0, 0.0, 0.0}
+
+		newHidden, err := cell.Forward(input, hiddenState)
+		if err != nil {
+			t.Fatalf("Forward pass failed: %v", err)
+		}
+
+		if len(newHidden) != 3 {
+			t.Errorf("Expected 3 hidden outputs, got %d", len(newHidden))
+		}
+
+		// Check that output is within tanh range [-1, 1]
+		for i, val := range newHidden {
+			if val < -1.0 || val > 1.0 {
+				t.Errorf("Hidden state[%d] = %f is outside tanh range [-1, 1]", i, val)
+			}
+		}
+	})
+
+	t.Run("InvalidInputSize", func(t *testing.T) {
+		cell := NewRNNCell(2, 3, Tanh)
+
+		input := []float64{1.0} // Wrong size
+		hiddenState := []float64{0.0, 0.0, 0.0}
+
+		_, err := cell.Forward(input, hiddenState)
+		if err == nil {
+			t.Error("Expected error for invalid input size")
+		}
+	})
+
+	t.Run("InvalidHiddenSize", func(t *testing.T) {
+		cell := NewRNNCell(2, 3, Tanh)
+
+		input := []float64{1.0, 0.5}
+		hiddenState := []float64{0.0, 0.0} // Wrong size
+
+		_, err := cell.Forward(input, hiddenState)
+		if err == nil {
+			t.Error("Expected error for invalid hidden state size")
+		}
+	})
+}
+
+// TestRNN tests complete RNN functionality
+func TestRNN(t *testing.T) {
+	t.Run("RNNCreation", func(t *testing.T) {
+		rnn := NewRNN(3, 4, 2, 0.01)
+
+		if rnn.Cell.InputSize != 3 {
+			t.Errorf("Expected input size 3, got %d", rnn.Cell.InputSize)
+		}
+		if rnn.Cell.HiddenSize != 4 {
+			t.Errorf("Expected hidden size 4, got %d", rnn.Cell.HiddenSize)
+		}
+		if rnn.OutputSize != 2 {
+			t.Errorf("Expected output size 2, got %d", rnn.OutputSize)
+		}
+		if rnn.LearningRate != 0.01 {
+			t.Errorf("Expected learning rate 0.01, got %f", rnn.LearningRate)
+		}
+		if len(rnn.OutputLayer) != 2 {
+			t.Errorf("Expected 2 output layer rows, got %d", len(rnn.OutputLayer))
+		}
+		if len(rnn.OutputLayer[0]) != 4 {
+			t.Errorf("Expected 4 output layer columns, got %d", len(rnn.OutputLayer[0]))
+		}
+	})
+
+	t.Run("SequenceForward", func(t *testing.T) {
+		rnn := NewRNN(2, 3, 1, 0.01)
+
+		// Simple sequence: 3 timesteps
+		sequence := [][]float64{
+			{1.0, 0.0},
+			{0.0, 1.0},
+			{1.0, 1.0},
+		}
+
+		outputs, err := rnn.ForwardSequence(sequence)
+		if err != nil {
+			t.Fatalf("Sequence forward failed: %v", err)
+		}
+
+		if len(outputs) != 3 {
+			t.Errorf("Expected 3 outputs, got %d", len(outputs))
+		}
+
+		for i, output := range outputs {
+			if len(output) != 1 {
+				t.Errorf("Output[%d] has wrong size: expected 1, got %d", i, len(output))
+			}
+		}
+
+		// Check that outputs are different (showing temporal dependency)
+		if outputs[0][0] == outputs[1][0] && outputs[1][0] == outputs[2][0] {
+			t.Error("All outputs are identical - RNN may not be working correctly")
+		}
+	})
+
+	t.Run("EmptySequence", func(t *testing.T) {
+		rnn := NewRNN(2, 3, 1, 0.01)
+
+		sequence := [][]float64{}
+
+		_, err := rnn.ForwardSequence(sequence)
+		if err == nil {
+			t.Error("Expected error for empty sequence")
+		}
+	})
+
+	t.Run("CacheValidation", func(t *testing.T) {
+		rnn := NewRNN(2, 3, 1, 0.01)
+
+		sequence := [][]float64{
+			{1.0, 0.0},
+			{0.0, 1.0},
+		}
+
+		_, err := rnn.ForwardSequence(sequence)
+		if err != nil {
+			t.Fatalf("Sequence forward failed: %v", err)
+		}
+
+		// Check that caches are populated
+		if rnn.Cell.InputCache == nil {
+			t.Error("Input cache is nil")
+		}
+		if rnn.Cell.HiddenCache == nil {
+			t.Error("Hidden cache is nil")
+		}
+		if rnn.Cell.OutputCache == nil {
+			t.Error("Output cache is nil")
+		}
+
+		if len(rnn.Cell.InputCache) != 2 {
+			t.Errorf("Expected 2 cached inputs, got %d", len(rnn.Cell.InputCache))
+		}
+		if len(rnn.Cell.HiddenCache) != 3 { // sequence_length + 1
+			t.Errorf("Expected 3 cached hidden states, got %d", len(rnn.Cell.HiddenCache))
+		}
+		if len(rnn.Cell.OutputCache) != 2 {
+			t.Errorf("Expected 2 cached outputs, got %d", len(rnn.Cell.OutputCache))
+		}
+	})
+}
+
+// TestRNNActivations tests different activation functions
+func TestRNNActivations(t *testing.T) {
+	testCases := []struct {
+		activation ActivationFunction
+		input      float64
+		minVal     float64
+		maxVal     float64
+	}{
+		{ReLU, 5.0, 0.0, math.Inf(1)},
+		{ReLU, -3.0, 0.0, 0.0},
+		{Sigmoid, 0.0, 0.0, 1.0},
+		{Tanh, 0.0, -1.0, 1.0},
+	}
+
+	for _, tc := range testCases {
+		cell := &RNNCell{Activation: tc.activation}
+		result := cell.activate(tc.input)
+
+		if result < tc.minVal || result > tc.maxVal {
+			t.Errorf("Activation %v with input %f: result %f outside range [%f, %f]",
+				tc.activation, tc.input, result, tc.minVal, tc.maxVal)
+		}
+	}
+}
+
+// TestRNNSequenceLearning tests that RNN can process different sequence patterns
+func TestRNNSequenceLearning(t *testing.T) {
+	t.Run("SequenceMemory", func(t *testing.T) {
+		rnn := NewRNN(1, 4, 1, 0.01)
+
+		// Test that RNN maintains memory across timesteps
+		sequence1 := [][]float64{
+			{1.0}, {0.0}, {0.0},
+		}
+		sequence2 := [][]float64{
+			{0.0}, {1.0}, {0.0},
+		}
+
+		outputs1, err := rnn.ForwardSequence(sequence1)
+		if err != nil {
+			t.Fatalf("Sequence 1 forward failed: %v", err)
+		}
+
+		outputs2, err := rnn.ForwardSequence(sequence2)
+		if err != nil {
+			t.Fatalf("Sequence 2 forward failed: %v", err)
+		}
+
+		// Final outputs should be different due to different input histories
+		finalOutput1 := outputs1[len(outputs1)-1][0]
+		finalOutput2 := outputs2[len(outputs2)-1][0]
+
+		if math.Abs(finalOutput1-finalOutput2) < 1e-6 {
+			t.Error("RNN outputs are too similar for different input sequences")
+		}
+	})
+
+	t.Run("LengthVariation", func(t *testing.T) {
+		rnn := NewRNN(1, 3, 1, 0.01)
+
+		// Test sequences of different lengths
+		shortSeq := [][]float64{
+			{1.0},
+		}
+		longSeq := [][]float64{
+			{1.0}, {0.5}, {0.2}, {0.1},
+		}
+
+		outputs1, err := rnn.ForwardSequence(shortSeq)
+		if err != nil {
+			t.Fatalf("Short sequence failed: %v", err)
+		}
+
+		outputs2, err := rnn.ForwardSequence(longSeq)
+		if err != nil {
+			t.Fatalf("Long sequence failed: %v", err)
+		}
+
+		if len(outputs1) != 1 {
+			t.Errorf("Expected 1 output for short sequence, got %d", len(outputs1))
+		}
+		if len(outputs2) != 4 {
+			t.Errorf("Expected 4 outputs for long sequence, got %d", len(outputs2))
+		}
+	})
+}


### PR DESCRIPTION
## 概要

GitHub Issue #47「Phase 2.0: CNN/RNN - Convolutional and Recurrent Neural Networks」を解決するため、畳み込みニューラルネットワーク（CNN）とリカレントニューラルネットワーク（RNN）を実装しました。

## 主要な実装内容

### CNN (Convolutional Neural Network) 完全実装
- **畳み込み層 (ConvLayer)**: 特徴抽出のためのlocal connectivityと重み共有
- **プーリング層 (PoolingLayer)**: Max/Average poolingによる次元削減と平行移動不変性
- **完全結合層統合**: softmax分類出力
- **誤差逆伝播**: 完全なgradient計算とweight更新機構
- **Xavier初期化**: 安定した学習のための重み初期化

### RNN (Recurrent Neural Network) 基本実装
- **RNNセル**: 隠れ状態の時系列計算 (h_t = tanh(W_h * h_{t-1} + W_x * x_t + b))
- **シーケンス処理**: 可変長入力への対応
- **活性化関数**: Tanh/ReLU/Sigmoid サポート
- **キャッシュ機構**: 将来の誤差逆伝播実装に向けた準備

### 学習重視設計
- **明示的数学実装**: ライブラリ依存を最小限に抑制
- **詳細な数学的コメント**: 各アルゴリズムの数学的背景説明
- **段階的理解促進**: 実装選択の学習観点説明

## テスト

包括的なテストスイートを実装:
- **単体テスト**: 各レイヤーの基本機能検証
- **結合テスト**: CNN全体の動作確認
- **エラーハンドリング**: 不正入力の適切な処理
- **パターン学習**: 実際の学習能力検証
- **数値精度**: 数学的正確性の確認

### テスト結果
- CNN: 全テストパス (前進・後進伝播、形状計算、学習機能)
- RNN: 全テストパス (セル動作、シーケンス処理、メモリ機能)
- 品質チェック: フォーマット・リント・テストすべて通過

## ファイル構成

```
phase2/
├── cnn.go        # CNN/RNN実装 (1000+ lines)
└── cnn_test.go   # 包括的テストスイート (1000+ lines)
```

Closes #47

🤖 Generated with [Claude Code](https://claude.ai/code)