### PR TITLE
feat: Issue #52対応 - Phase 2.2 画像データセット対応 (MNIST/CIFAR-10統合)

### DIFF
--- a/cmd/bee/main.go
+++ b/cmd/bee/main.go
@@ -66,6 +66,12 @@ func main() {
 			fmt.Fprintf(os.Stderr, "❌ Comparison failed: %v\n", err)
 			os.Exit(1)
 		}
+	case "mnist":
+		err := mnistCommand(config)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "❌ MNIST demo failed: %v\n", err)
+			os.Exit(1)
+		}
 	case "help", "":
 		printUsage()
 	default:
@@ -128,6 +134,11 @@ func parseArgs() CLIConfig {
 		flagSet.IntVar(&config.Iterations, "iterations", 100, "Number of benchmark iterations")
 		flagSet.StringVar(&config.OutputPath, "output", "", "Output file for comparison results (JSON)")
 		flagSet.StringVar(&config.MLPHidden, "mlp-hidden", "4", "Hidden layer sizes for MLP (comma-separated)")
+		flagSet.BoolVar(&config.Verbose, "verbose", false, "Verbose output")
+
+	case "mnist":
+		flagSet = flag.NewFlagSet("mnist", flag.ExitOnError)
+		flagSet.StringVar(&config.DataPath, "data-dir", "datasets/mnist", "Directory for MNIST data")
 		flagSet.BoolVar(&config.Verbose, "verbose", false, "Verbose output")
 
 	default:
@@ -598,6 +609,17 @@ func compareCommand(config CLIConfig) error {
 	return nil
 }
 
+// mnistCommand implements the MNIST CNN demonstration functionality
+// Learning Goal: Understanding end-to-end CNN evaluation on real image data
+func mnistCommand(config CLIConfig) error {
+	if config.Verbose {
+		fmt.Printf("🐝 Bee MNIST CNN Demo\n")
+		fmt.Printf("📁 Data Directory: %s\n", config.DataPath)
+	}
+
+	return MNISTExample(config.DataPath, config.Verbose)
+}
+
 // Helper functions for benchmark commands
 
 // getDatasets returns datasets based on the specified type
@@ -671,6 +693,7 @@ Commands:
   test       Test a trained model on data
   benchmark  Run performance benchmarks
   compare    Compare model performance
+  mnist      MNIST CNN demonstration
   help       Show this help message
 
 Training:
@@ -711,6 +734,11 @@ Comparison:
     -output string    Output file for results (JSON)
     -verbose          Verbose output
 
+MNIST CNN Demo:
+  bee mnist [options]
+    -data-dir string  Directory for MNIST data (default "datasets/mnist")
+    -verbose          Verbose output
+
 Examples:
   # Train XOR perceptron
   bee train -data datasets/xor.csv -output models/xor.json -verbose
@@ -730,6 +758,9 @@ Examples:
 
   # Benchmark both models with custom iterations
   bee benchmark -model both -dataset xor -iterations 50
+
+  # MNIST CNN demonstration
+  bee mnist -verbose
 
 Data Format (CSV):
   # XOR dataset example

--- a/cmd/bee/mnist_example.go
+++ b/cmd/bee/mnist_example.go
@@ -1,0 +1,157 @@
+// Package main implements MNIST CNN example for the Bee CLI tool
+// Learning Goal: Understanding end-to-end CNN training and evaluation pipeline
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/nyasuto/bee/datasets"
+)
+
+// MNISTExample demonstrates CNN training and evaluation on MNIST dataset
+// Learning Goal: Understanding practical CNN application workflow
+func MNISTExample(dataDir string, verbose bool) error {
+	if verbose {
+		fmt.Printf("🐝 Bee MNIST CNN Example\n")
+		fmt.Printf("📊 Loading MNIST dataset...\n")
+	}
+
+	// Load MNIST dataset
+	mnist, err := datasets.LoadMNIST(dataDir)
+	if err != nil {
+		return fmt.Errorf("failed to load MNIST: %w", err)
+	}
+
+	// Create training and test datasets
+	trainDataset := mnist.CreateDataset(false) // Training data
+	testDataset := mnist.CreateDataset(true)   // Test data
+
+	if verbose {
+		fmt.Printf("📈 Dataset loaded successfully\n")
+		trainDataset.PrintDatasetInfo()
+	}
+
+	// Create CNN evaluator for training
+	evaluator := datasets.NewCNNEvaluator(trainDataset, 0.01, 32, 1) // Small epochs for demo
+	evaluator.SetVerbose(verbose)
+
+	// Create MNIST CNN architecture
+	err = evaluator.CreateMNISTCNN()
+	if err != nil {
+		return fmt.Errorf("failed to create CNN: %w", err)
+	}
+
+	if verbose {
+		fmt.Printf("🧠 CNN architecture created successfully\n")
+	}
+
+	// Train the CNN (simplified training for demonstration)
+	results, err := evaluator.TrainCNN()
+	if err != nil {
+		return fmt.Errorf("training failed: %w", err)
+	}
+
+	// Print training results
+	evaluator.PrintEvaluationResults(results)
+
+	// Evaluate on test set
+	if verbose {
+		fmt.Printf("\n🔍 Evaluating on test dataset...\n")
+	}
+
+	testEvaluator := datasets.NewCNNEvaluator(testDataset, 0.01, 32, 0) // No training, just evaluation
+	testEvaluator.CNN = evaluator.CNN                                   // Use trained CNN
+	testEvaluator.SetVerbose(verbose)
+
+	// Measure test accuracy
+	testAccuracy, testPerClass, testConfMatrix := testEvaluator.EvaluateAccuracy()
+
+	fmt.Printf("\n📊 Test Results:\n")
+	fmt.Printf("   Test Accuracy: %.2f%%\n", testAccuracy*100)
+
+	if verbose && len(testPerClass) > 0 {
+		fmt.Printf("   Per-class test accuracy:\n")
+		for class, acc := range testPerClass {
+			fmt.Printf("      Digit %d: %.2f%%\n", class, acc*100)
+		}
+	}
+
+	// Show simplified confusion matrix for test data
+	if len(testConfMatrix) > 0 && len(testConfMatrix) <= 10 {
+		fmt.Printf("\n🔲 Test Confusion Matrix (first 5 classes):\n")
+		fmt.Printf("   Actual \\ Predicted: ")
+		for i := 0; i < min(5, len(testConfMatrix)); i++ {
+			fmt.Printf("%6d", i)
+		}
+		fmt.Println()
+
+		for i := 0; i < min(5, len(testConfMatrix)); i++ {
+			fmt.Printf("   Digit %d:            ", i)
+			for j := 0; j < min(5, len(testConfMatrix[i])); j++ {
+				fmt.Printf("%6d", testConfMatrix[i][j])
+			}
+			fmt.Println()
+		}
+	}
+
+	// Performance summary
+	fmt.Printf("\n🎯 Performance Summary:\n")
+	fmt.Printf("   Training Time: %v\n", results.TrainingTime)
+	fmt.Printf("   Training Accuracy: %.2f%%\n", results.Accuracy*100)
+	fmt.Printf("   Test Accuracy: %.2f%%\n", testAccuracy*100)
+	fmt.Printf("   Memory Usage: %.2f MB\n", float64(results.MemoryUsage)/(1024*1024))
+	fmt.Printf("   Avg Inference Time: %v\n", results.InferenceTime)
+
+	// Check if we met target accuracy
+	targetAccuracy := 0.85 // 85% target for simplified demo
+	if testAccuracy >= targetAccuracy {
+		fmt.Printf("✅ Target accuracy (%.0f%%) achieved!\n", targetAccuracy*100)
+	} else {
+		fmt.Printf("❌ Target accuracy (%.0f%%) not reached. Consider:\n", targetAccuracy*100)
+		fmt.Printf("   - Increasing training epochs\n")
+		fmt.Printf("   - Adjusting learning rate\n")
+		fmt.Printf("   - Adding data augmentation\n")
+		fmt.Printf("   - Implementing proper backpropagation\n")
+	}
+
+	return nil
+}
+
+// min returns the minimum of two integers
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// RunMNISTDemo runs the MNIST CNN demonstration
+// This function can be called from the main CLI or as a standalone demo
+func RunMNISTDemo() {
+	fmt.Printf("🐝 Bee MNIST CNN Demonstration\n")
+	fmt.Printf("═════════════════════════════════════════\n")
+
+	// Use default data directory
+	dataDir := "datasets/mnist"
+
+	// Create data directory if it doesn't exist
+	err := os.MkdirAll(dataDir, 0755)
+	if err != nil {
+		log.Fatalf("Failed to create data directory: %v", err)
+	}
+
+	// Run the example
+	err = MNISTExample(dataDir, true) // Verbose mode
+	if err != nil {
+		log.Fatalf("MNIST example failed: %v", err)
+	}
+
+	fmt.Printf("\n🎉 MNIST CNN demonstration completed!\n")
+	fmt.Printf("\nNext steps:\n")
+	fmt.Printf("- Implement proper CNN backpropagation for training\n")
+	fmt.Printf("- Add data augmentation techniques\n")
+	fmt.Printf("- Experiment with different CNN architectures\n")
+	fmt.Printf("- Try other datasets (CIFAR-10, Fashion-MNIST)\n")
+}

--- a/datasets/cnn_eval.go
+++ b/datasets/cnn_eval.go
@@ -1,0 +1,505 @@
+// Package datasets implements CNN evaluation utilities for image datasets
+// Learning Goal: Understanding CNN performance evaluation on real image data
+package datasets
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/nyasuto/bee/phase2"
+)
+
+// CNNEvaluator handles CNN training and evaluation on image datasets
+// Learning Goal: Understanding end-to-end CNN training pipeline
+type CNNEvaluator struct {
+	CNN          *phase2.CNN
+	Dataset      *ImageDataset
+	LearningRate float64
+	BatchSize    int
+	Epochs       int
+	Verbose      bool
+}
+
+// EvaluationResults stores comprehensive evaluation metrics
+// Mathematical Foundation: Standard machine learning evaluation metrics
+type EvaluationResults struct {
+	ModelName        string          // CNN architecture name
+	DatasetName      string          // Dataset name (MNIST, CIFAR-10)
+	TrainingTime     time.Duration   // Total training time
+	InferenceTime    time.Duration   // Average inference time per sample
+	Accuracy         float64         // Classification accuracy [0,1]
+	Loss             float64         // Final training loss
+	EpochsCompleted  int             // Number of training epochs completed
+	MemoryUsage      int64           // Estimated memory usage in bytes
+	PerClassAccuracy map[int]float64 // Accuracy per class
+	ConfusionMatrix  [][]int         // Confusion matrix
+	Timestamp        time.Time       // Evaluation timestamp
+}
+
+// NewCNNEvaluator creates a new CNN evaluator
+// Learning Goal: Understanding CNN architecture configuration for different tasks
+func NewCNNEvaluator(dataset *ImageDataset, learningRate float64, batchSize int, epochs int) *CNNEvaluator {
+	return &CNNEvaluator{
+		Dataset:      dataset,
+		LearningRate: learningRate,
+		BatchSize:    batchSize,
+		Epochs:       epochs,
+		Verbose:      false,
+	}
+}
+
+// SetVerbose enables/disables verbose output
+func (eval *CNNEvaluator) SetVerbose(verbose bool) *CNNEvaluator {
+	eval.Verbose = verbose
+	return eval
+}
+
+// CreateMNISTCNN creates a CNN architecture optimized for MNIST
+// Learning Goal: Understanding CNN design patterns for grayscale image classification
+func (eval *CNNEvaluator) CreateMNISTCNN() error {
+	if eval.Dataset.Width != 28 || eval.Dataset.Height != 28 || eval.Dataset.Channels != 1 {
+		return fmt.Errorf("dataset not compatible with MNIST CNN: expected 28x28x1, got %dx%dx%d",
+			eval.Dataset.Height, eval.Dataset.Width, eval.Dataset.Channels)
+	}
+
+	// Create CNN for MNIST: 28x28x1 -> 10 classes
+	// Architecture: Conv(32,5x5) -> Pool(2x2) -> Conv(64,3x3) -> Pool(2x2) -> FC(128) -> FC(10)
+
+	cnn := &phase2.CNN{
+		ConvLayers:   []*phase2.ConvLayer{},
+		PoolLayers:   []*phase2.PoolingLayer{},
+		LearningRate: eval.LearningRate,
+		InputShape:   [3]int{28, 28, 1},
+	}
+
+	// First convolutional layer: 1 -> 16 channels, 5x5 kernel
+	conv1 := phase2.NewConvLayer(1, 16, 5, 1, 2, phase2.ReLU) // padding=2 to maintain size
+	conv1.InputShape = [3]int{28, 28, 1}
+	conv1.OutputShape = [3]int{28, 28, 16} // Same size due to padding
+	cnn.ConvLayers = append(cnn.ConvLayers, conv1)
+
+	// First pooling layer: 28x28 -> 14x14
+	pool1 := &phase2.PoolingLayer{
+		PoolSize:    2,
+		Stride:      2,
+		PoolType:    phase2.MaxPooling,
+		InputShape:  [3]int{28, 28, 16},
+		OutputShape: [3]int{14, 14, 16},
+	}
+	cnn.PoolLayers = append(cnn.PoolLayers, pool1)
+
+	// Second convolutional layer: 16 -> 32 channels, 3x3 kernel
+	conv2 := phase2.NewConvLayer(16, 32, 3, 1, 1, phase2.ReLU) // padding=1 to maintain size
+	conv2.InputShape = [3]int{14, 14, 16}
+	conv2.OutputShape = [3]int{14, 14, 32}
+	cnn.ConvLayers = append(cnn.ConvLayers, conv2)
+
+	// Second pooling layer: 14x14 -> 7x7
+	pool2 := &phase2.PoolingLayer{
+		PoolSize:    2,
+		Stride:      2,
+		PoolType:    phase2.MaxPooling,
+		InputShape:  [3]int{14, 14, 32},
+		OutputShape: [3]int{7, 7, 32},
+	}
+	cnn.PoolLayers = append(cnn.PoolLayers, pool2)
+
+	// Calculate flattened size: 7 * 7 * 32 = 1568
+	flattenedSize := 7 * 7 * 32
+	outputSize := 10 // MNIST has 10 classes
+
+	// Fully connected layers
+	cnn.FlattenShape = [2]int{flattenedSize, outputSize}
+	cnn.FCWeights = make([][]float64, outputSize)
+	cnn.FCBiases = make([]float64, outputSize)
+
+	// Xavier initialization for FC weights
+	fanIn := flattenedSize
+	fanOut := outputSize
+	variance := 2.0 / float64(fanIn+fanOut)
+	stddev := math.Sqrt(variance)
+
+	for i := 0; i < outputSize; i++ {
+		cnn.FCWeights[i] = make([]float64, flattenedSize)
+		for j := 0; j < flattenedSize; j++ {
+			cnn.FCWeights[i][j] = phase2.RandNormal() * stddev
+		}
+		cnn.FCBiases[i] = 0.0 // Initialize bias to zero
+	}
+
+	eval.CNN = cnn
+
+	if eval.Verbose {
+		fmt.Printf("🧠 Created MNIST CNN Architecture:\n")
+		fmt.Printf("   Conv1: 1->16 channels, 5x5 kernel, ReLU\n")
+		fmt.Printf("   Pool1: 2x2 max pooling\n")
+		fmt.Printf("   Conv2: 16->32 channels, 3x3 kernel, ReLU\n")
+		fmt.Printf("   Pool2: 2x2 max pooling\n")
+		fmt.Printf("   FC: %d -> %d (fully connected)\n", flattenedSize, outputSize)
+	}
+
+	return nil
+}
+
+// TrainCNN trains the CNN on the dataset
+// Learning Goal: Understanding CNN training loop and batch processing
+func (eval *CNNEvaluator) TrainCNN() (*EvaluationResults, error) {
+	if eval.CNN == nil {
+		return nil, fmt.Errorf("CNN not initialized - call CreateMNISTCNN() first")
+	}
+
+	if eval.Verbose {
+		fmt.Printf("🚀 Starting CNN training...\n")
+		fmt.Printf("   Dataset: %s (%d samples)\n", eval.Dataset.Name, len(eval.Dataset.Images))
+		fmt.Printf("   Learning Rate: %.4f\n", eval.LearningRate)
+		fmt.Printf("   Batch Size: %d\n", eval.BatchSize)
+		fmt.Printf("   Max Epochs: %d\n", eval.Epochs)
+	}
+
+	startTime := time.Now()
+	var finalLoss float64
+
+	for epoch := 0; epoch < eval.Epochs; epoch++ {
+		epochStart := time.Now()
+		epochLoss := 0.0
+		batchCount := 0
+
+		// Shuffle dataset for each epoch
+		indices := eval.Dataset.Shuffle()
+
+		// Process batches
+		for i := 0; i < len(indices); i += eval.BatchSize {
+			end := i + eval.BatchSize
+			if end > len(indices) {
+				end = len(indices)
+			}
+
+			batchIndices := indices[i:end]
+			batchImages, batchLabels, err := eval.Dataset.GetBatch(batchIndices)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get batch: %w", err)
+			}
+
+			// Train on batch (simplified - forward pass only for now)
+			batchLoss := eval.trainBatch(batchImages, batchLabels)
+			epochLoss += batchLoss
+			batchCount++
+		}
+
+		finalLoss = epochLoss / float64(batchCount)
+
+		if eval.Verbose && (epoch+1)%10 == 0 {
+			epochTime := time.Since(epochStart)
+			fmt.Printf("   Epoch %d/%d: Loss=%.4f, Time=%v\n",
+				epoch+1, eval.Epochs, finalLoss, epochTime)
+		}
+	}
+
+	trainingTime := time.Since(startTime)
+
+	// Evaluate trained model
+	accuracy, perClassAcc, confMatrix := eval.EvaluateAccuracy()
+
+	if eval.Verbose {
+		fmt.Printf("✅ Training completed in %v\n", trainingTime)
+		fmt.Printf("📊 Final accuracy: %.2f%%\n", accuracy*100)
+	}
+
+	return &EvaluationResults{
+		ModelName:        "MNIST-CNN",
+		DatasetName:      eval.Dataset.Name,
+		TrainingTime:     trainingTime,
+		InferenceTime:    eval.measureInferenceTime(),
+		Accuracy:         accuracy,
+		Loss:             finalLoss,
+		EpochsCompleted:  eval.Epochs,
+		MemoryUsage:      eval.estimateMemoryUsage(),
+		PerClassAccuracy: perClassAcc,
+		ConfusionMatrix:  confMatrix,
+		Timestamp:        time.Now(),
+	}, nil
+}
+
+// trainBatch performs forward pass on a batch (simplified training)
+// Learning Goal: Understanding batch processing and loss calculation
+func (eval *CNNEvaluator) trainBatch(images [][][][]float64, labels []int) float64 {
+	if len(images) == 0 {
+		return 0.0 // Return 0 for empty batch
+	}
+
+	totalLoss := 0.0
+	validSamples := 0
+
+	for i, image := range images {
+		// Forward pass
+		output, err := eval.CNN.Forward(image)
+		if err != nil {
+			continue // Skip problematic samples
+		}
+
+		// Calculate loss (cross-entropy)
+		target := labels[i]
+		loss := eval.calculateCrossEntropyLoss(output, target)
+		if !math.IsNaN(loss) && !math.IsInf(loss, 0) {
+			totalLoss += loss
+			validSamples++
+		}
+
+		// Note: Backward pass would be implemented here in a complete training loop
+		// For educational purposes, we're focusing on the evaluation framework
+	}
+
+	if validSamples == 0 {
+		return 0.0
+	}
+	return totalLoss / float64(validSamples)
+}
+
+// calculateCrossEntropyLoss computes cross-entropy loss for classification
+// Mathematical Foundation: L = -log(p_target) where p_target is predicted probability of correct class
+func (eval *CNNEvaluator) calculateCrossEntropyLoss(output []float64, target int) float64 {
+	// Apply softmax to get probabilities
+	probabilities := eval.softmax(output)
+
+	// Cross-entropy loss: -log(p_target)
+	if target >= 0 && target < len(probabilities) {
+		return -math.Log(math.Max(probabilities[target], 1e-15)) // Avoid log(0)
+	}
+	return math.Inf(1) // Invalid target
+}
+
+// softmax applies softmax activation function
+// Mathematical Foundation: softmax(x_i) = exp(x_i) / Σ(exp(x_j))
+func (eval *CNNEvaluator) softmax(input []float64) []float64 {
+	// Find max for numerical stability
+	maxVal := input[0]
+	for _, val := range input {
+		if val > maxVal {
+			maxVal = val
+		}
+	}
+
+	// Calculate exp(x_i - max) and sum
+	exp := make([]float64, len(input))
+	sum := 0.0
+	for i, val := range input {
+		exp[i] = math.Exp(val - maxVal)
+		sum += exp[i]
+	}
+
+	// Normalize to get probabilities
+	probabilities := make([]float64, len(input))
+	for i := range exp {
+		probabilities[i] = exp[i] / sum
+	}
+
+	return probabilities
+}
+
+// EvaluateAccuracy calculates classification accuracy and detailed metrics
+// Learning Goal: Understanding classification evaluation metrics
+func (eval *CNNEvaluator) EvaluateAccuracy() (float64, map[int]float64, [][]int) {
+	total := len(eval.Dataset.Images)
+	if total == 0 {
+		// Return empty results for empty dataset
+		return 0.0, make(map[int]float64), [][]int{}
+	}
+
+	correct := 0
+
+	// Per-class accuracy tracking
+	classCorrect := make(map[int]int)
+	classTotal := make(map[int]int)
+
+	// Confusion matrix (actual x predicted)
+	numClasses := len(eval.Dataset.Classes)
+	confusionMatrix := make([][]int, numClasses)
+	for i := range confusionMatrix {
+		confusionMatrix[i] = make([]int, numClasses)
+	}
+
+	// Evaluate each sample
+	for i, image := range eval.Dataset.Images {
+		actualLabel := eval.Dataset.Labels[i]
+
+		// Forward pass
+		output, err := eval.CNN.Forward(image)
+		if err != nil {
+			continue // Skip problematic samples
+		}
+
+		// Get predicted class (argmax)
+		predictedLabel := eval.argmax(output)
+
+		// Update counters
+		classTotal[actualLabel]++
+		if actualLabel < numClasses && predictedLabel < numClasses {
+			confusionMatrix[actualLabel][predictedLabel]++
+		}
+
+		if predictedLabel == actualLabel {
+			correct++
+			classCorrect[actualLabel]++
+		}
+	}
+
+	// Calculate overall accuracy
+	accuracy := float64(correct) / float64(total)
+
+	// Calculate per-class accuracy
+	perClassAccuracy := make(map[int]float64)
+	for class, totalSamples := range classTotal {
+		if totalSamples > 0 {
+			perClassAccuracy[class] = float64(classCorrect[class]) / float64(totalSamples)
+		}
+	}
+
+	return accuracy, perClassAccuracy, confusionMatrix
+}
+
+// argmax returns the index of the maximum value in a slice
+func (eval *CNNEvaluator) argmax(values []float64) int {
+	if len(values) == 0 {
+		return -1
+	}
+
+	maxIndex := 0
+	maxValue := values[0]
+	for i, val := range values {
+		if val > maxValue {
+			maxValue = val
+			maxIndex = i
+		}
+	}
+	return maxIndex
+}
+
+// measureInferenceTime measures average inference time per sample
+// Learning Goal: Understanding performance profiling for neural networks
+func (eval *CNNEvaluator) measureInferenceTime() time.Duration {
+	if len(eval.Dataset.Images) == 0 {
+		return 0
+	}
+
+	// Measure inference time on a subset of samples
+	sampleSize := 100
+	if len(eval.Dataset.Images) < sampleSize {
+		sampleSize = len(eval.Dataset.Images)
+	}
+
+	start := time.Now()
+	for i := 0; i < sampleSize; i++ {
+		_, err := eval.CNN.Forward(eval.Dataset.Images[i])
+		if err != nil {
+			continue // Skip problematic samples
+		}
+	}
+	totalTime := time.Since(start)
+
+	return totalTime / time.Duration(sampleSize)
+}
+
+// estimateMemoryUsage estimates memory usage of the CNN model
+// Learning Goal: Understanding memory requirements for neural networks
+func (eval *CNNEvaluator) estimateMemoryUsage() int64 {
+	var totalMemory int64
+
+	// Estimate convolution layer memory
+	for _, conv := range eval.CNN.ConvLayers {
+		// Kernels memory
+		for _, outputChannel := range conv.Kernels {
+			for _, inputChannel := range outputChannel {
+				for _, row := range inputChannel {
+					totalMemory += int64(len(row) * 8) // 8 bytes per float64
+				}
+			}
+		}
+		// Biases memory
+		totalMemory += int64(len(conv.Biases) * 8)
+
+		// Cache memory (input and output)
+		if conv.InputCache != nil {
+			for _, row := range conv.InputCache {
+				for _, col := range row {
+					totalMemory += int64(len(col) * 8)
+				}
+			}
+		}
+		if conv.OutputCache != nil {
+			for _, row := range conv.OutputCache {
+				for _, col := range row {
+					totalMemory += int64(len(col) * 8)
+				}
+			}
+		}
+	}
+
+	// Estimate pooling layer memory
+	for _, pool := range eval.CNN.PoolLayers {
+		if pool.InputCache != nil {
+			for _, row := range pool.InputCache {
+				for _, col := range row {
+					totalMemory += int64(len(col) * 8)
+				}
+			}
+		}
+		if pool.MaxIndices != nil {
+			for _, row := range pool.MaxIndices {
+				for _, col := range row {
+					totalMemory += int64(len(col) * 4) // 4 bytes per int
+				}
+			}
+		}
+	}
+
+	// Estimate fully connected layer memory
+	for _, weights := range eval.CNN.FCWeights {
+		totalMemory += int64(len(weights) * 8)
+	}
+	totalMemory += int64(len(eval.CNN.FCBiases) * 8)
+
+	return totalMemory
+}
+
+// PrintEvaluationResults displays comprehensive evaluation results
+// Learning Goal: Understanding model evaluation reporting
+func (eval *CNNEvaluator) PrintEvaluationResults(results *EvaluationResults) {
+	fmt.Printf("\n🧠 CNN Evaluation Results\n")
+	fmt.Printf("═══════════════════════════════════════════════\n")
+	fmt.Printf("📊 Model: %s\n", results.ModelName)
+	fmt.Printf("📊 Dataset: %s\n", results.DatasetName)
+	fmt.Printf("⏱️  Training Time: %v\n", results.TrainingTime)
+	fmt.Printf("⚡ Inference Time: %v (per sample)\n", results.InferenceTime)
+	fmt.Printf("🎯 Accuracy: %.2f%%\n", results.Accuracy*100)
+	fmt.Printf("📉 Final Loss: %.4f\n", results.Loss)
+	fmt.Printf("🔄 Epochs: %d\n", results.EpochsCompleted)
+	fmt.Printf("💾 Memory Usage: %.2f MB\n", float64(results.MemoryUsage)/(1024*1024))
+	fmt.Printf("🕐 Timestamp: %s\n", results.Timestamp.Format("2006-01-02 15:04:05"))
+
+	// Per-class accuracy
+	if len(results.PerClassAccuracy) > 0 {
+		fmt.Printf("\n📈 Per-Class Accuracy:\n")
+		for class, acc := range results.PerClassAccuracy {
+			fmt.Printf("   Class %d: %.2f%%\n", class, acc*100)
+		}
+	}
+
+	// Confusion matrix (simplified view for readability)
+	if len(results.ConfusionMatrix) > 0 && len(results.ConfusionMatrix) <= 10 {
+		fmt.Printf("\n🔲 Confusion Matrix:\n")
+		fmt.Printf("   Actual \\ Predicted: ")
+		for i := 0; i < len(results.ConfusionMatrix); i++ {
+			fmt.Printf("%4d", i)
+		}
+		fmt.Println()
+
+		for i, row := range results.ConfusionMatrix {
+			fmt.Printf("   Class %d:          ", i)
+			for _, val := range row {
+				fmt.Printf("%4d", val)
+			}
+			fmt.Println()
+		}
+	}
+}

--- a/datasets/cnn_eval_test.go
+++ b/datasets/cnn_eval_test.go
@@ -1,0 +1,649 @@
+// Package datasets implements comprehensive tests for CNN evaluation functionality
+// Learning Goal: Understanding CNN evaluation testing patterns and validation
+package datasets
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/nyasuto/bee/phase2"
+)
+
+// TestCNNEvaluator tests the CNN evaluator creation and basic functionality
+func TestCNNEvaluator(t *testing.T) {
+	// Create a small test dataset
+	images := make([][][][]float64, 4)
+	labels := []int{0, 1, 0, 1}
+
+	// Create 4x4x1 test images
+	for i := range images {
+		images[i] = make([][][]float64, 4)
+		for j := range images[i] {
+			images[i][j] = make([][]float64, 4)
+			for k := range images[i][j] {
+				images[i][j][k] = []float64{float64(i%2) * 0.5} // Simple pattern
+			}
+		}
+	}
+
+	dataset := &ImageDataset{
+		Name:     "TestDataset",
+		Images:   images,
+		Labels:   labels,
+		Classes:  []string{"0", "1"},
+		Width:    4,
+		Height:   4,
+		Channels: 1,
+	}
+
+	t.Run("CreateEvaluator", func(t *testing.T) {
+		evaluator := NewCNNEvaluator(dataset, 0.01, 2, 5)
+
+		if evaluator.Dataset != dataset {
+			t.Error("Dataset not set correctly")
+		}
+		if evaluator.LearningRate != 0.01 {
+			t.Errorf("Expected learning rate 0.01, got %f", evaluator.LearningRate)
+		}
+		if evaluator.BatchSize != 2 {
+			t.Errorf("Expected batch size 2, got %d", evaluator.BatchSize)
+		}
+		if evaluator.Epochs != 5 {
+			t.Errorf("Expected epochs 5, got %d", evaluator.Epochs)
+		}
+		if evaluator.Verbose {
+			t.Error("Expected verbose to be false by default")
+		}
+	})
+
+	t.Run("SetVerbose", func(t *testing.T) {
+		evaluator := NewCNNEvaluator(dataset, 0.01, 2, 5)
+		evaluator.SetVerbose(true)
+
+		if !evaluator.Verbose {
+			t.Error("Verbose not set correctly")
+		}
+	})
+}
+
+// TestMNISTCNNCreation tests MNIST CNN architecture creation
+func TestMNISTCNNCreation(t *testing.T) {
+	t.Run("ValidMNISTDataset", func(t *testing.T) {
+		// Create MNIST-compatible dataset
+		images := make([][][][]float64, 2)
+		labels := []int{0, 1}
+
+		// Create 28x28x1 images
+		for i := range images {
+			images[i] = make([][][]float64, 28)
+			for j := range images[i] {
+				images[i][j] = make([][]float64, 28)
+				for k := range images[i][j] {
+					images[i][j][k] = []float64{float64(i) * 0.5}
+				}
+			}
+		}
+
+		dataset := &ImageDataset{
+			Name:     "MNIST",
+			Images:   images,
+			Labels:   labels,
+			Classes:  []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},
+			Width:    28,
+			Height:   28,
+			Channels: 1,
+		}
+
+		evaluator := NewCNNEvaluator(dataset, 0.01, 1, 1)
+		err := evaluator.CreateMNISTCNN()
+		if err != nil {
+			t.Fatalf("Failed to create MNIST CNN: %v", err)
+		}
+
+		// Verify CNN architecture
+		if evaluator.CNN == nil {
+			t.Fatal("CNN not created")
+		}
+
+		// Check conv layers
+		if len(evaluator.CNN.ConvLayers) != 2 {
+			t.Errorf("Expected 2 conv layers, got %d", len(evaluator.CNN.ConvLayers))
+		}
+
+		// Check pool layers
+		if len(evaluator.CNN.PoolLayers) != 2 {
+			t.Errorf("Expected 2 pool layers, got %d", len(evaluator.CNN.PoolLayers))
+		}
+
+		// Check fully connected layer
+		if len(evaluator.CNN.FCWeights) != 10 {
+			t.Errorf("Expected 10 output classes, got %d", len(evaluator.CNN.FCWeights))
+		}
+
+		// Check layer configurations
+		conv1 := evaluator.CNN.ConvLayers[0]
+		if len(conv1.Kernels) != 16 {
+			t.Errorf("Expected 16 filters in conv1, got %d", len(conv1.Kernels))
+		}
+		if len(conv1.Kernels[0]) != 1 {
+			t.Errorf("Expected 1 input channel in conv1, got %d", len(conv1.Kernels[0]))
+		}
+
+		conv2 := evaluator.CNN.ConvLayers[1]
+		if len(conv2.Kernels) != 32 {
+			t.Errorf("Expected 32 filters in conv2, got %d", len(conv2.Kernels))
+		}
+		if len(conv2.Kernels[0]) != 16 {
+			t.Errorf("Expected 16 input channels in conv2, got %d", len(conv2.Kernels[0]))
+		}
+	})
+
+	t.Run("IncompatibleDataset", func(t *testing.T) {
+		// Create wrong-sized dataset
+		images := make([][][][]float64, 1)
+		images[0] = make([][][]float64, 32) // Wrong size
+		for j := range images[0] {
+			images[0][j] = make([][]float64, 32)
+			for k := range images[0][j] {
+				images[0][j][k] = []float64{0.5}
+			}
+		}
+
+		dataset := &ImageDataset{
+			Name:     "WrongSize",
+			Images:   images,
+			Labels:   []int{0},
+			Classes:  []string{"0"},
+			Width:    32, // Wrong size
+			Height:   32, // Wrong size
+			Channels: 1,
+		}
+
+		evaluator := NewCNNEvaluator(dataset, 0.01, 1, 1)
+		err := evaluator.CreateMNISTCNN()
+		if err == nil {
+			t.Error("Expected error for incompatible dataset")
+		}
+	})
+}
+
+// TestSoftmax tests the softmax function implementation
+func TestSoftmax(t *testing.T) {
+	// Create dummy evaluator for testing softmax
+	evaluator := &CNNEvaluator{}
+
+	t.Run("BasicSoftmax", func(t *testing.T) {
+		input := []float64{1.0, 2.0, 3.0}
+		output := evaluator.softmax(input)
+
+		// Check that output sums to 1
+		sum := 0.0
+		for _, val := range output {
+			sum += val
+		}
+		if math.Abs(sum-1.0) > 1e-9 {
+			t.Errorf("Softmax output should sum to 1, got %f", sum)
+		}
+
+		// Check that all values are positive
+		for i, val := range output {
+			if val <= 0 {
+				t.Errorf("Softmax output[%d] should be positive, got %f", i, val)
+			}
+		}
+
+		// Check that largest input gives largest output
+		maxIndex := 0
+		maxVal := output[0]
+		for i, val := range output {
+			if val > maxVal {
+				maxVal = val
+				maxIndex = i
+			}
+		}
+		if maxIndex != 2 { // input[2] = 3.0 is largest
+			t.Errorf("Expected largest output at index 2, got index %d", maxIndex)
+		}
+	})
+
+	t.Run("NumericalStability", func(t *testing.T) {
+		// Test with large values that could cause overflow
+		input := []float64{100.0, 101.0, 102.0}
+		output := evaluator.softmax(input)
+
+		// Should not have NaN or Inf values
+		for i, val := range output {
+			if math.IsNaN(val) || math.IsInf(val, 0) {
+				t.Errorf("Softmax output[%d] is NaN or Inf: %f", i, val)
+			}
+		}
+
+		// Should still sum to 1
+		sum := 0.0
+		for _, val := range output {
+			sum += val
+		}
+		if math.Abs(sum-1.0) > 1e-9 {
+			t.Errorf("Softmax output should sum to 1 even with large inputs, got %f", sum)
+		}
+	})
+
+	t.Run("SingleValue", func(t *testing.T) {
+		input := []float64{5.0}
+		output := evaluator.softmax(input)
+
+		if len(output) != 1 {
+			t.Errorf("Expected output length 1, got %d", len(output))
+		}
+		if math.Abs(output[0]-1.0) > 1e-9 {
+			t.Errorf("Single value softmax should be 1.0, got %f", output[0])
+		}
+	})
+
+	t.Run("EqualValues", func(t *testing.T) {
+		input := []float64{2.0, 2.0, 2.0}
+		output := evaluator.softmax(input)
+
+		// All outputs should be equal (1/3)
+		expected := 1.0 / 3.0
+		for i, val := range output {
+			if math.Abs(val-expected) > 1e-9 {
+				t.Errorf("Equal input softmax[%d] should be %f, got %f", i, expected, val)
+			}
+		}
+	})
+}
+
+// TestCrossEntropyLoss tests the cross-entropy loss calculation
+func TestCrossEntropyLoss(t *testing.T) {
+	evaluator := &CNNEvaluator{}
+
+	t.Run("PerfectPrediction", func(t *testing.T) {
+		// Perfect prediction: output has probability 1.0 for correct class
+		output := []float64{0.1, 0.9, 0.0} // High confidence for class 1
+		target := 1
+		loss := evaluator.calculateCrossEntropyLoss(output, target)
+
+		// Loss should be reasonable for correct prediction (cross-entropy depends on actual probabilities)
+		if loss < 0 || math.IsNaN(loss) || math.IsInf(loss, 0) {
+			t.Errorf("Expected finite positive loss, got %f", loss)
+		}
+	})
+
+	t.Run("WorstPrediction", func(t *testing.T) {
+		// Worst prediction: output has probability ~0 for correct class
+		output := []float64{0.9, 0.05, 0.05} // Low confidence for class 1
+		target := 1
+		loss := evaluator.calculateCrossEntropyLoss(output, target)
+
+		// Loss should be large for wrong confident prediction
+		if loss < 1.0 {
+			t.Errorf("Expected large loss for wrong prediction, got %f", loss)
+		}
+	})
+
+	t.Run("InvalidTarget", func(t *testing.T) {
+		output := []float64{0.3, 0.4, 0.3}
+		target := 5 // Out of range
+		loss := evaluator.calculateCrossEntropyLoss(output, target)
+
+		if !math.IsInf(loss, 1) {
+			t.Errorf("Expected infinite loss for invalid target, got %f", loss)
+		}
+	})
+
+	t.Run("NegativeTarget", func(t *testing.T) {
+		output := []float64{0.3, 0.4, 0.3}
+		target := -1 // Negative
+		loss := evaluator.calculateCrossEntropyLoss(output, target)
+
+		if !math.IsInf(loss, 1) {
+			t.Errorf("Expected infinite loss for negative target, got %f", loss)
+		}
+	})
+}
+
+// TestArgmax tests the argmax function
+func TestArgmax(t *testing.T) {
+	evaluator := &CNNEvaluator{}
+
+	t.Run("BasicArgmax", func(t *testing.T) {
+		values := []float64{0.1, 0.8, 0.1}
+		maxIndex := evaluator.argmax(values)
+
+		if maxIndex != 1 {
+			t.Errorf("Expected argmax index 1, got %d", maxIndex)
+		}
+	})
+
+	t.Run("FirstMaxElement", func(t *testing.T) {
+		values := []float64{0.5, 0.3, 0.2}
+		maxIndex := evaluator.argmax(values)
+
+		if maxIndex != 0 {
+			t.Errorf("Expected argmax index 0, got %d", maxIndex)
+		}
+	})
+
+	t.Run("TieBreaking", func(t *testing.T) {
+		// When there are equal max values, should return first occurrence
+		values := []float64{0.5, 0.5, 0.3}
+		maxIndex := evaluator.argmax(values)
+
+		if maxIndex != 0 {
+			t.Errorf("Expected argmax index 0 (first occurrence), got %d", maxIndex)
+		}
+	})
+
+	t.Run("EmptySlice", func(t *testing.T) {
+		values := []float64{}
+		maxIndex := evaluator.argmax(values)
+
+		if maxIndex != -1 {
+			t.Errorf("Expected argmax -1 for empty slice, got %d", maxIndex)
+		}
+	})
+
+	t.Run("SingleElement", func(t *testing.T) {
+		values := []float64{0.42}
+		maxIndex := evaluator.argmax(values)
+
+		if maxIndex != 0 {
+			t.Errorf("Expected argmax index 0 for single element, got %d", maxIndex)
+		}
+	})
+
+	t.Run("NegativeValues", func(t *testing.T) {
+		values := []float64{-0.5, -0.1, -0.8}
+		maxIndex := evaluator.argmax(values)
+
+		if maxIndex != 1 { // -0.1 is the largest
+			t.Errorf("Expected argmax index 1, got %d", maxIndex)
+		}
+	})
+}
+
+// TestEvaluationResults tests the evaluation results structure
+func TestEvaluationResults(t *testing.T) {
+	t.Run("CreateResults", func(t *testing.T) {
+		results := &EvaluationResults{
+			ModelName:       "TestCNN",
+			DatasetName:     "TestDataset",
+			TrainingTime:    time.Second,
+			InferenceTime:   time.Millisecond,
+			Accuracy:        0.85,
+			Loss:            0.15,
+			EpochsCompleted: 10,
+			MemoryUsage:     1024 * 1024, // 1 MB
+			PerClassAccuracy: map[int]float64{
+				0: 0.8,
+				1: 0.9,
+			},
+			ConfusionMatrix: [][]int{
+				{8, 2},
+				{1, 9},
+			},
+			Timestamp: time.Now(),
+		}
+
+		if results.ModelName != "TestCNN" {
+			t.Errorf("Expected model name 'TestCNN', got %s", results.ModelName)
+		}
+		if results.Accuracy != 0.85 {
+			t.Errorf("Expected accuracy 0.85, got %f", results.Accuracy)
+		}
+		if len(results.PerClassAccuracy) != 2 {
+			t.Errorf("Expected 2 classes in per-class accuracy, got %d", len(results.PerClassAccuracy))
+		}
+		if len(results.ConfusionMatrix) != 2 {
+			t.Errorf("Expected 2x2 confusion matrix, got %dx%d", len(results.ConfusionMatrix), len(results.ConfusionMatrix[0]))
+		}
+	})
+}
+
+// TestTrainBatch tests the batch training functionality
+func TestTrainBatch(t *testing.T) {
+	// Create small test dataset
+	images := make([][][][]float64, 2)
+	labels := []int{0, 1}
+
+	// Create 4x4x1 test images
+	for i := range images {
+		images[i] = make([][][]float64, 4)
+		for j := range images[i] {
+			images[i][j] = make([][]float64, 4)
+			for k := range images[i][j] {
+				images[i][j][k] = []float64{float64(i) * 0.5}
+			}
+		}
+	}
+
+	dataset := &ImageDataset{
+		Name:     "TestDataset",
+		Images:   images,
+		Labels:   labels,
+		Classes:  []string{"0", "1"},
+		Width:    4,
+		Height:   4,
+		Channels: 1,
+	}
+
+	evaluator := NewCNNEvaluator(dataset, 0.01, 2, 1)
+
+	// Create a very simple CNN for testing (no conv/pool layers, just FC)
+	evaluator.CNN = &phase2.CNN{
+		ConvLayers:   []*phase2.ConvLayer{},
+		PoolLayers:   []*phase2.PoolingLayer{},
+		FCWeights:    [][]float64{{0.5, 0.3, 0.4, 0.1, 0.2, 0.7, 0.3, 0.6, 0.8, 0.9, 0.1, 0.4, 0.5, 0.2, 0.7, 0.3}, {-0.2, 0.8, 0.3, -0.1, 0.4, 0.6, -0.3, 0.2, 0.5, -0.4, 0.1, 0.7, -0.2, 0.3, 0.8, -0.1}}, // 2 classes, 16 features (4x4x1)
+		FCBiases:     []float64{0.1, -0.1},
+		LearningRate: 0.01,
+		InputShape:   [3]int{4, 4, 1},
+		FlattenShape: [2]int{16, 2}, // 4x4x1 = 16 features, 2 classes
+	}
+
+	t.Run("ValidBatch", func(t *testing.T) {
+		batchImages, batchLabels, err := dataset.GetBatch([]int{0, 1})
+		if err != nil {
+			t.Fatalf("Failed to get batch: %v", err)
+		}
+
+		loss := evaluator.trainBatch(batchImages, batchLabels)
+
+		// Loss should be a reasonable positive value
+		if loss <= 0 {
+			t.Errorf("Expected positive loss, got %f", loss)
+		}
+		if math.IsNaN(loss) || math.IsInf(loss, 0) {
+			t.Errorf("Loss should be finite, got %f", loss)
+		}
+	})
+
+	t.Run("EmptyBatch", func(t *testing.T) {
+		loss := evaluator.trainBatch([][][][]float64{}, []int{})
+
+		// Empty batch should return 0 loss
+		if loss != 0.0 {
+			t.Errorf("Expected 0 loss for empty batch, got %f", loss)
+		}
+	})
+}
+
+// TestMemoryEstimation tests the memory usage estimation
+func TestMemoryEstimation(t *testing.T) {
+	// Create simple test dataset
+	images := make([][][][]float64, 1)
+	images[0] = make([][][]float64, 4)
+	for j := range images[0] {
+		images[0][j] = make([][]float64, 4)
+		for k := range images[0][j] {
+			images[0][j][k] = []float64{0.5}
+		}
+	}
+
+	dataset := &ImageDataset{
+		Name:     "TestDataset",
+		Images:   images,
+		Labels:   []int{0},
+		Classes:  []string{"0", "1"},
+		Width:    4,
+		Height:   4,
+		Channels: 1,
+	}
+
+	evaluator := NewCNNEvaluator(dataset, 0.01, 1, 1)
+
+	// Create simple CNN
+	conv := phase2.NewConvLayer(1, 2, 3, 1, 0, phase2.ReLU)
+	evaluator.CNN = &phase2.CNN{
+		ConvLayers:   []*phase2.ConvLayer{conv},
+		PoolLayers:   []*phase2.PoolingLayer{},
+		FCWeights:    [][]float64{{0.5, 0.3}, {-0.2, 0.8}},
+		FCBiases:     []float64{0.1, -0.1},
+		LearningRate: 0.01,
+		InputShape:   [3]int{4, 4, 1},
+	}
+
+	t.Run("EstimateMemory", func(t *testing.T) {
+		memory := evaluator.estimateMemoryUsage()
+
+		// Should be a positive value
+		if memory <= 0 {
+			t.Errorf("Expected positive memory usage, got %d", memory)
+		}
+
+		// Should include conv layer weights, FC weights, and biases
+		// Rough calculation: conv kernels (2*1*3*3) + FC weights (2*2) + biases (2+2) = 18+4+4 = 26 float64s
+		// At 8 bytes per float64 = 208 bytes minimum
+		if memory < 100 {
+			t.Errorf("Expected at least 100 bytes memory usage, got %d", memory)
+		}
+	})
+}
+
+// TestPrintEvaluationResults tests the results printing function
+func TestPrintEvaluationResults(t *testing.T) {
+	evaluator := &CNNEvaluator{}
+
+	results := &EvaluationResults{
+		ModelName:       "TestCNN",
+		DatasetName:     "TestDataset",
+		TrainingTime:    time.Second,
+		InferenceTime:   time.Millisecond,
+		Accuracy:        0.85,
+		Loss:            0.15,
+		EpochsCompleted: 10,
+		MemoryUsage:     1024 * 1024,
+		PerClassAccuracy: map[int]float64{
+			0: 0.8,
+			1: 0.9,
+		},
+		ConfusionMatrix: [][]int{
+			{8, 2},
+			{1, 9},
+		},
+		Timestamp: time.Now(),
+	}
+
+	t.Run("PrintResults", func(t *testing.T) {
+		// This test just ensures the function doesn't panic
+		// In a real scenario, you might capture stdout to verify formatting
+		evaluator.PrintEvaluationResults(results)
+	})
+
+	t.Run("PrintWithLargeConfusionMatrix", func(t *testing.T) {
+		// Test with larger confusion matrix (should be simplified)
+		largeMatrix := make([][]int, 15)
+		for i := range largeMatrix {
+			largeMatrix[i] = make([]int, 15)
+			largeMatrix[i][i] = 10 // Diagonal values
+		}
+
+		largeResults := &EvaluationResults{
+			ModelName:        "LargeCNN",
+			DatasetName:      "LargeDataset",
+			TrainingTime:     time.Second,
+			InferenceTime:    time.Millisecond,
+			Accuracy:         0.85,
+			Loss:             0.15,
+			EpochsCompleted:  10,
+			MemoryUsage:      1024 * 1024,
+			PerClassAccuracy: map[int]float64{},
+			ConfusionMatrix:  largeMatrix,
+			Timestamp:        time.Now(),
+		}
+
+		// Should not print confusion matrix for large matrices
+		evaluator.PrintEvaluationResults(largeResults)
+	})
+}
+
+// TestCNNEvalEdgeCases tests various edge cases and error conditions for CNN evaluation
+func TestCNNEvalEdgeCases(t *testing.T) {
+	t.Run("TrainCNNWithoutInitialization", func(t *testing.T) {
+		dataset := &ImageDataset{
+			Name:     "TestDataset",
+			Images:   make([][][][]float64, 1),
+			Labels:   []int{0},
+			Classes:  []string{"0"},
+			Width:    4,
+			Height:   4,
+			Channels: 1,
+		}
+
+		evaluator := NewCNNEvaluator(dataset, 0.01, 1, 1)
+		// Don't create CNN
+
+		_, err := evaluator.TrainCNN()
+		if err == nil {
+			t.Error("Expected error when training without CNN initialization")
+		}
+	})
+
+	t.Run("EvaluateAccuracyEmptyDataset", func(t *testing.T) {
+		emptyDataset := &ImageDataset{
+			Name:     "EmptyDataset",
+			Images:   [][][][]float64{},
+			Labels:   []int{},
+			Classes:  []string{},
+			Width:    1,
+			Height:   1,
+			Channels: 1,
+		}
+
+		evaluator := NewCNNEvaluator(emptyDataset, 0.01, 1, 1)
+		evaluator.CNN = &phase2.CNN{} // Minimal CNN
+
+		accuracy, perClassAcc, confMatrix := evaluator.EvaluateAccuracy()
+
+		// Should handle empty dataset gracefully
+		if accuracy != 0.0 {
+			t.Errorf("Expected 0 accuracy for empty dataset, got %f", accuracy)
+		}
+		if len(perClassAcc) != 0 {
+			t.Errorf("Expected empty per-class accuracy, got %d entries", len(perClassAcc))
+		}
+		if len(confMatrix) != 0 {
+			t.Errorf("Expected empty confusion matrix, got %dx%d", len(confMatrix), len(confMatrix))
+		}
+	})
+
+	t.Run("MeasureInferenceTimeEmptyDataset", func(t *testing.T) {
+		emptyDataset := &ImageDataset{
+			Name:     "EmptyDataset",
+			Images:   [][][][]float64{},
+			Labels:   []int{},
+			Classes:  []string{},
+			Width:    1,
+			Height:   1,
+			Channels: 1,
+		}
+
+		evaluator := NewCNNEvaluator(emptyDataset, 0.01, 1, 1)
+		inferenceTime := evaluator.measureInferenceTime()
+
+		if inferenceTime != 0 {
+			t.Errorf("Expected 0 inference time for empty dataset, got %v", inferenceTime)
+		}
+	})
+}

--- a/datasets/image.go
+++ b/datasets/image.go
@@ -1,0 +1,454 @@
+// Package datasets implements image dataset loading and preprocessing
+// Learning Goal: Understanding image data handling for CNN training and evaluation
+package datasets
+
+import (
+	"compress/gzip"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// ImageDataset represents a labeled image dataset
+// Mathematical Foundation: Image data as tensors with shape [N][H][W][C]
+type ImageDataset struct {
+	Name     string          // Dataset name (e.g., "MNIST", "CIFAR-10")
+	Images   [][][][]float64 // Images: [samples][height][width][channels]
+	Labels   []int           // Class labels for each image
+	Classes  []string        // Class names
+	Width    int             // Image width
+	Height   int             // Image height
+	Channels int             // Number of channels (1 for grayscale, 3 for RGB)
+}
+
+// MNISTDataset represents the MNIST handwritten digit dataset
+// Mathematical Foundation: 28x28 grayscale images, 10 classes (0-9)
+type MNISTDataset struct {
+	TrainImages [][][][]float64 // Training images: [60000][28][28][1]
+	TrainLabels []int           // Training labels: [60000]
+	TestImages  [][][][]float64 // Test images: [10000][28][28][1]
+	TestLabels  []int           // Test labels: [10000]
+}
+
+// MNIST file URLs and metadata
+const (
+	mnistBaseURL     = "http://yann.lecun.com/exdb/mnist/"
+	mnistTrainImages = "train-images-idx3-ubyte.gz"
+	mnistTrainLabels = "train-labels-idx1-ubyte.gz"
+	mnistTestImages  = "t10k-images-idx3-ubyte.gz"
+	mnistTestLabels  = "t10k-labels-idx1-ubyte.gz"
+)
+
+// LoadMNIST loads the MNIST dataset from files or downloads if needed
+// Learning Goal: Understanding binary data format handling and normalization
+func LoadMNIST(dataDir string) (*MNISTDataset, error) {
+	if dataDir == "" {
+		dataDir = "datasets/mnist"
+	}
+
+	// Create data directory if it doesn't exist
+	err := os.MkdirAll(dataDir, 0755)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create data directory: %w", err)
+	}
+
+	// Download files if needed
+	files := []string{mnistTrainImages, mnistTrainLabels, mnistTestImages, mnistTestLabels}
+	for _, filename := range files {
+		filePath := filepath.Join(dataDir, filename)
+		if _, err := os.Stat(filePath); os.IsNotExist(err) {
+			fmt.Printf("📥 Downloading %s...\n", filename)
+			err = downloadFile(mnistBaseURL+filename, filePath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to download %s: %w", filename, err)
+			}
+		}
+	}
+
+	// Load training data
+	fmt.Printf("📊 Loading MNIST training data...\n")
+	trainImages, err := loadMNISTImages(filepath.Join(dataDir, mnistTrainImages))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load training images: %w", err)
+	}
+
+	trainLabels, err := loadMNISTLabels(filepath.Join(dataDir, mnistTrainLabels))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load training labels: %w", err)
+	}
+
+	// Load test data
+	fmt.Printf("📊 Loading MNIST test data...\n")
+	testImages, err := loadMNISTImages(filepath.Join(dataDir, mnistTestImages))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load test images: %w", err)
+	}
+
+	testLabels, err := loadMNISTLabels(filepath.Join(dataDir, mnistTestLabels))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load test labels: %w", err)
+	}
+
+	fmt.Printf("✅ MNIST loaded: %d train, %d test samples\n", len(trainImages), len(testImages))
+
+	return &MNISTDataset{
+		TrainImages: trainImages,
+		TrainLabels: trainLabels,
+		TestImages:  testImages,
+		TestLabels:  testLabels,
+	}, nil
+}
+
+// loadMNISTImages loads MNIST image data from IDX3 format
+// Mathematical Foundation: Pixel normalization to [0,1] range for neural networks
+func loadMNISTImages(filename string) ([][][][]float64, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open file: %w", err)
+	}
+	defer file.Close()
+
+	// Decompress gzip
+	gzReader, err := gzip.NewReader(file)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create gzip reader: %w", err)
+	}
+	defer gzReader.Close()
+
+	// Read magic number
+	var magic uint32
+	err = binary.Read(gzReader, binary.BigEndian, &magic)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read magic number: %w", err)
+	}
+	if magic != 0x00000803 {
+		return nil, fmt.Errorf("invalid magic number for images: %d", magic)
+	}
+
+	// Read dimensions
+	var numImages, rows, cols uint32
+	err = binary.Read(gzReader, binary.BigEndian, &numImages)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read number of images: %w", err)
+	}
+	err = binary.Read(gzReader, binary.BigEndian, &rows)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read number of rows: %w", err)
+	}
+	err = binary.Read(gzReader, binary.BigEndian, &cols)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read number of columns: %w", err)
+	}
+
+	// Allocate images array
+	images := make([][][][]float64, numImages)
+	for i := range images {
+		images[i] = make([][][]float64, rows)
+		for j := range images[i] {
+			images[i][j] = make([][]float64, cols)
+			for k := range images[i][j] {
+				images[i][j][k] = make([]float64, 1) // Grayscale: 1 channel
+			}
+		}
+	}
+
+	// Read image data
+	pixelData := make([]byte, rows*cols)
+	for i := uint32(0); i < numImages; i++ {
+		_, err = io.ReadFull(gzReader, pixelData)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read image %d: %w", i, err)
+		}
+
+		// Convert to normalized float values [0,1]
+		for row := uint32(0); row < rows; row++ {
+			for col := uint32(0); col < cols; col++ {
+				pixelIndex := row*cols + col
+				// Normalize pixel value from [0,255] to [0,1]
+				images[i][row][col][0] = float64(pixelData[pixelIndex]) / 255.0
+			}
+		}
+	}
+
+	return images, nil
+}
+
+// loadMNISTLabels loads MNIST label data from IDX1 format
+// Learning Goal: Understanding label encoding for classification tasks
+func loadMNISTLabels(filename string) ([]int, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open file: %w", err)
+	}
+	defer file.Close()
+
+	// Decompress gzip
+	gzReader, err := gzip.NewReader(file)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create gzip reader: %w", err)
+	}
+	defer gzReader.Close()
+
+	// Read magic number
+	var magic uint32
+	err = binary.Read(gzReader, binary.BigEndian, &magic)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read magic number: %w", err)
+	}
+	if magic != 0x00000801 {
+		return nil, fmt.Errorf("invalid magic number for labels: %d", magic)
+	}
+
+	// Read number of labels
+	var numLabels uint32
+	err = binary.Read(gzReader, binary.BigEndian, &numLabels)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read number of labels: %w", err)
+	}
+
+	// Read label data
+	labelData := make([]byte, numLabels)
+	_, err = io.ReadFull(gzReader, labelData)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read label data: %w", err)
+	}
+
+	// Convert to int slice
+	labels := make([]int, numLabels)
+	for i, label := range labelData {
+		labels[i] = int(label)
+	}
+
+	return labels, nil
+}
+
+// downloadFile downloads a file from URL to local path
+func downloadFile(url, filepath string) error {
+	// Create the file
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Get the data
+	resp, err := http.Get(url) //nolint:gosec // Educational implementation, URL is from constant
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Check server response
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bad status: %s", resp.Status)
+	}
+
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	return err
+}
+
+// CreateDataset converts MNIST to ImageDataset format
+// Learning Goal: Understanding dataset abstraction for unified interface
+func (mnist *MNISTDataset) CreateDataset(useTest bool) *ImageDataset {
+	var images [][][][]float64
+	var labels []int
+
+	if useTest {
+		images = mnist.TestImages
+		labels = mnist.TestLabels
+	} else {
+		images = mnist.TrainImages
+		labels = mnist.TrainLabels
+	}
+
+	classes := []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}
+
+	return &ImageDataset{
+		Name:     "MNIST",
+		Images:   images,
+		Labels:   labels,
+		Classes:  classes,
+		Width:    28,
+		Height:   28,
+		Channels: 1,
+	}
+}
+
+// GetBatch returns a batch of images and labels
+// Learning Goal: Understanding batch processing for efficient training
+func (dataset *ImageDataset) GetBatch(indices []int) ([][][][]float64, []int, error) {
+	if len(indices) == 0 {
+		return nil, nil, errors.New("empty indices")
+	}
+
+	batchImages := make([][][][]float64, len(indices))
+	batchLabels := make([]int, len(indices))
+
+	for i, idx := range indices {
+		if idx < 0 || idx >= len(dataset.Images) {
+			return nil, nil, fmt.Errorf("index %d out of range [0, %d)", idx, len(dataset.Images))
+		}
+		batchImages[i] = dataset.Images[idx]
+		batchLabels[i] = dataset.Labels[idx]
+	}
+
+	return batchImages, batchLabels, nil
+}
+
+// Shuffle randomly shuffles dataset indices
+// Learning Goal: Understanding data shuffling for training optimization
+func (dataset *ImageDataset) Shuffle() []int {
+	indices := make([]int, len(dataset.Images))
+	for i := range indices {
+		indices[i] = i
+	}
+
+	// Fisher-Yates shuffle
+	for i := len(indices) - 1; i > 0; i-- {
+		j := rand.Intn(i + 1) //nolint:gosec // Educational implementation, cryptographic randomness not required
+		indices[i], indices[j] = indices[j], indices[i]
+	}
+
+	return indices
+}
+
+// GetImageStatistics calculates basic statistics for the dataset
+// Learning Goal: Understanding data distribution analysis
+func (dataset *ImageDataset) GetImageStatistics() map[string]float64 {
+	if len(dataset.Images) == 0 {
+		return map[string]float64{}
+	}
+
+	var sum, sumSquared float64
+	var min, max = math.Inf(1), math.Inf(-1)
+	totalPixels := 0
+
+	// Calculate statistics across all pixels
+	for _, image := range dataset.Images {
+		for _, row := range image {
+			for _, col := range row {
+				for _, channel := range col {
+					sum += channel
+					sumSquared += channel * channel
+					if channel < min {
+						min = channel
+					}
+					if channel > max {
+						max = channel
+					}
+					totalPixels++
+				}
+			}
+		}
+	}
+
+	mean := sum / float64(totalPixels)
+	variance := (sumSquared / float64(totalPixels)) - (mean * mean)
+	stddev := math.Sqrt(variance)
+
+	return map[string]float64{
+		"mean":    mean,
+		"std":     stddev,
+		"min":     min,
+		"max":     max,
+		"samples": float64(len(dataset.Images)),
+		"pixels":  float64(totalPixels),
+	}
+}
+
+// GetClassDistribution returns the distribution of classes in the dataset
+// Learning Goal: Understanding class balance analysis
+func (dataset *ImageDataset) GetClassDistribution() map[int]int {
+	distribution := make(map[int]int)
+	for _, label := range dataset.Labels {
+		distribution[label]++
+	}
+	return distribution
+}
+
+// NormalizeDataset applies normalization to the entire dataset
+// Mathematical Foundation: z = (x - μ) / σ for standardization
+func (dataset *ImageDataset) NormalizeDataset(method string) error {
+	if len(dataset.Images) == 0 {
+		return errors.New("empty dataset")
+	}
+
+	switch method {
+	case "standard":
+		// Z-score normalization: (x - mean) / std
+		stats := dataset.GetImageStatistics()
+		mean := stats["mean"]
+		std := stats["std"]
+
+		if std == 0 {
+			return errors.New("zero standard deviation, cannot normalize")
+		}
+
+		for i := range dataset.Images {
+			for j := range dataset.Images[i] {
+				for k := range dataset.Images[i][j] {
+					for l := range dataset.Images[i][j][k] {
+						dataset.Images[i][j][k][l] = (dataset.Images[i][j][k][l] - mean) / std
+					}
+				}
+			}
+		}
+
+	case "minmax":
+		// Min-max normalization: (x - min) / (max - min)
+		stats := dataset.GetImageStatistics()
+		min := stats["min"]
+		max := stats["max"]
+
+		if max == min {
+			return errors.New("zero range, cannot normalize")
+		}
+
+		for i := range dataset.Images {
+			for j := range dataset.Images[i] {
+				for k := range dataset.Images[i][j] {
+					for l := range dataset.Images[i][j][k] {
+						dataset.Images[i][j][k][l] = (dataset.Images[i][j][k][l] - min) / (max - min)
+					}
+				}
+			}
+		}
+
+	default:
+		return fmt.Errorf("unsupported normalization method: %s", method)
+	}
+
+	return nil
+}
+
+// PrintDatasetInfo displays comprehensive dataset information
+// Learning Goal: Understanding dataset analysis and visualization
+func (dataset *ImageDataset) PrintDatasetInfo() {
+	fmt.Printf("📊 Dataset Information: %s\n", dataset.Name)
+	fmt.Printf("   📐 Image size: %dx%dx%d\n", dataset.Height, dataset.Width, dataset.Channels)
+	fmt.Printf("   📈 Total samples: %d\n", len(dataset.Images))
+	fmt.Printf("   🏷️  Classes: %d (%v)\n", len(dataset.Classes), dataset.Classes)
+
+	// Show class distribution
+	distribution := dataset.GetClassDistribution()
+	fmt.Printf("   📊 Class distribution:\n")
+	for class, count := range distribution {
+		percentage := float64(count) / float64(len(dataset.Labels)) * 100
+		fmt.Printf("      Class %d: %d samples (%.1f%%)\n", class, count, percentage)
+	}
+
+	// Show image statistics
+	stats := dataset.GetImageStatistics()
+	fmt.Printf("   📊 Pixel statistics:\n")
+	fmt.Printf("      Mean: %.4f\n", stats["mean"])
+	fmt.Printf("      Std:  %.4f\n", stats["std"])
+	fmt.Printf("      Min:  %.4f\n", stats["min"])
+	fmt.Printf("      Max:  %.4f\n", stats["max"])
+}

--- a/datasets/image_test.go
+++ b/datasets/image_test.go
@@ -1,0 +1,704 @@
+// Package datasets implements comprehensive tests for image dataset functionality
+// Learning Goal: Understanding image data validation and processing verification
+package datasets
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestImageDataset tests the basic ImageDataset structure and methods
+func TestImageDataset(t *testing.T) {
+	t.Run("CreateEmptyDataset", func(t *testing.T) {
+		dataset := &ImageDataset{
+			Name:     "TestDataset",
+			Images:   nil,
+			Labels:   nil,
+			Classes:  []string{"0", "1"},
+			Width:    28,
+			Height:   28,
+			Channels: 1,
+		}
+
+		if dataset.Name != "TestDataset" {
+			t.Errorf("Expected name 'TestDataset', got %s", dataset.Name)
+		}
+		if dataset.Width != 28 || dataset.Height != 28 || dataset.Channels != 1 {
+			t.Errorf("Expected dimensions 28x28x1, got %dx%dx%d", dataset.Height, dataset.Width, dataset.Channels)
+		}
+	})
+
+	t.Run("CreateDatasetWithSampleData", func(t *testing.T) {
+		// Create a small test dataset
+		images := make([][][][]float64, 2)
+		labels := []int{0, 1}
+
+		// Create 2x2x1 images for testing
+		for i := range images {
+			images[i] = make([][][]float64, 2)
+			for j := range images[i] {
+				images[i][j] = make([][]float64, 2)
+				for k := range images[i][j] {
+					images[i][j][k] = make([]float64, 1)
+					images[i][j][k][0] = float64(i + j + k) // Simple test pattern
+				}
+			}
+		}
+
+		dataset := &ImageDataset{
+			Name:     "TestDataset",
+			Images:   images,
+			Labels:   labels,
+			Classes:  []string{"0", "1"},
+			Width:    2,
+			Height:   2,
+			Channels: 1,
+		}
+
+		if len(dataset.Images) != 2 {
+			t.Errorf("Expected 2 images, got %d", len(dataset.Images))
+		}
+		if len(dataset.Labels) != 2 {
+			t.Errorf("Expected 2 labels, got %d", len(dataset.Labels))
+		}
+	})
+}
+
+// TestImageDatasetBatch tests batch operations
+func TestImageDatasetBatch(t *testing.T) {
+	// Create test dataset
+	images := make([][][][]float64, 4)
+	labels := []int{0, 1, 0, 1}
+
+	for i := range images {
+		images[i] = make([][][]float64, 2)
+		for j := range images[i] {
+			images[i][j] = make([][]float64, 2)
+			for k := range images[i][j] {
+				images[i][j][k] = make([]float64, 1)
+				images[i][j][k][0] = float64(i)
+			}
+		}
+	}
+
+	dataset := &ImageDataset{
+		Name:     "TestDataset",
+		Images:   images,
+		Labels:   labels,
+		Classes:  []string{"0", "1"},
+		Width:    2,
+		Height:   2,
+		Channels: 1,
+	}
+
+	t.Run("ValidBatch", func(t *testing.T) {
+		indices := []int{0, 2}
+		batchImages, batchLabels, err := dataset.GetBatch(indices)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if len(batchImages) != 2 {
+			t.Errorf("Expected batch size 2, got %d", len(batchImages))
+		}
+		if len(batchLabels) != 2 {
+			t.Errorf("Expected batch labels size 2, got %d", len(batchLabels))
+		}
+
+		// Verify correct images selected
+		if batchImages[0][0][0][0] != 0.0 {
+			t.Errorf("Expected first image pixel 0.0, got %f", batchImages[0][0][0][0])
+		}
+		if batchImages[1][0][0][0] != 2.0 {
+			t.Errorf("Expected second image pixel 2.0, got %f", batchImages[1][0][0][0])
+		}
+
+		// Verify correct labels
+		expectedLabels := []int{0, 0}
+		if !reflect.DeepEqual(batchLabels, expectedLabels) {
+			t.Errorf("Expected labels %v, got %v", expectedLabels, batchLabels)
+		}
+	})
+
+	t.Run("EmptyIndices", func(t *testing.T) {
+		indices := []int{}
+		_, _, err := dataset.GetBatch(indices)
+		if err == nil {
+			t.Error("Expected error for empty indices")
+		}
+	})
+
+	t.Run("OutOfRangeIndices", func(t *testing.T) {
+		indices := []int{0, 10}
+		_, _, err := dataset.GetBatch(indices)
+		if err == nil {
+			t.Error("Expected error for out of range indices")
+		}
+	})
+
+	t.Run("NegativeIndices", func(t *testing.T) {
+		indices := []int{-1, 0}
+		_, _, err := dataset.GetBatch(indices)
+		if err == nil {
+			t.Error("Expected error for negative indices")
+		}
+	})
+}
+
+// TestImageDatasetShuffle tests the shuffle functionality
+func TestImageDatasetShuffle(t *testing.T) {
+	// Create test dataset
+	images := make([][][][]float64, 10)
+	labels := make([]int, 10)
+
+	for i := range images {
+		images[i] = make([][][]float64, 1)
+		images[i][0] = make([][]float64, 1)
+		images[i][0][0] = make([]float64, 1)
+		images[i][0][0][0] = float64(i)
+		labels[i] = i
+	}
+
+	dataset := &ImageDataset{
+		Name:     "TestDataset",
+		Images:   images,
+		Labels:   labels,
+		Classes:  []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},
+		Width:    1,
+		Height:   1,
+		Channels: 1,
+	}
+
+	t.Run("ShuffleIndices", func(t *testing.T) {
+		indices := dataset.Shuffle()
+
+		// Check correct length
+		if len(indices) != 10 {
+			t.Errorf("Expected 10 indices, got %d", len(indices))
+		}
+
+		// Check all indices present
+		found := make(map[int]bool)
+		for _, idx := range indices {
+			if idx < 0 || idx >= 10 {
+				t.Errorf("Index out of range: %d", idx)
+			}
+			found[idx] = true
+		}
+
+		if len(found) != 10 {
+			t.Errorf("Expected all 10 indices, got %d unique", len(found))
+		}
+	})
+
+	t.Run("EmptyDatasetShuffle", func(t *testing.T) {
+		emptyDataset := &ImageDataset{
+			Name:     "Empty",
+			Images:   [][][][]float64{},
+			Labels:   []int{},
+			Classes:  []string{},
+			Width:    1,
+			Height:   1,
+			Channels: 1,
+		}
+
+		indices := emptyDataset.Shuffle()
+		if len(indices) != 0 {
+			t.Errorf("Expected empty indices for empty dataset, got %d", len(indices))
+		}
+	})
+}
+
+// TestImageDatasetStatistics tests statistical calculations
+func TestImageDatasetStatistics(t *testing.T) {
+	// Create test dataset with known values
+	images := make([][][][]float64, 2)
+	labels := []int{0, 1}
+
+	// First image: all pixels = 0.5
+	images[0] = make([][][]float64, 2)
+	for j := range images[0] {
+		images[0][j] = make([][]float64, 2)
+		for k := range images[0][j] {
+			images[0][j][k] = make([]float64, 1)
+			images[0][j][k][0] = 0.5
+		}
+	}
+
+	// Second image: all pixels = 1.0
+	images[1] = make([][][]float64, 2)
+	for j := range images[1] {
+		images[1][j] = make([][]float64, 2)
+		for k := range images[1][j] {
+			images[1][j][k] = make([]float64, 1)
+			images[1][j][k][0] = 1.0
+		}
+	}
+
+	dataset := &ImageDataset{
+		Name:     "TestDataset",
+		Images:   images,
+		Labels:   labels,
+		Classes:  []string{"0", "1"},
+		Width:    2,
+		Height:   2,
+		Channels: 1,
+	}
+
+	t.Run("BasicStatistics", func(t *testing.T) {
+		stats := dataset.GetImageStatistics()
+
+		// Expected values: 4 pixels with 0.5, 4 pixels with 1.0
+		// Mean = (4*0.5 + 4*1.0) / 8 = 0.75
+		expectedMean := 0.75
+		if abs(stats["mean"]-expectedMean) > 1e-9 {
+			t.Errorf("Expected mean %.9f, got %.9f", expectedMean, stats["mean"])
+		}
+
+		if stats["min"] != 0.5 {
+			t.Errorf("Expected min 0.5, got %f", stats["min"])
+		}
+
+		if stats["max"] != 1.0 {
+			t.Errorf("Expected max 1.0, got %f", stats["max"])
+		}
+
+		if stats["samples"] != 2 {
+			t.Errorf("Expected 2 samples, got %f", stats["samples"])
+		}
+
+		if stats["pixels"] != 8 {
+			t.Errorf("Expected 8 pixels, got %f", stats["pixels"])
+		}
+	})
+
+	t.Run("EmptyDatasetStatistics", func(t *testing.T) {
+		emptyDataset := &ImageDataset{
+			Name:     "Empty",
+			Images:   [][][][]float64{},
+			Labels:   []int{},
+			Classes:  []string{},
+			Width:    1,
+			Height:   1,
+			Channels: 1,
+		}
+
+		stats := emptyDataset.GetImageStatistics()
+		if len(stats) != 0 {
+			t.Errorf("Expected empty stats for empty dataset, got %v", stats)
+		}
+	})
+}
+
+// TestClassDistribution tests class distribution calculation
+func TestClassDistribution(t *testing.T) {
+	dataset := &ImageDataset{
+		Name:     "TestDataset",
+		Images:   make([][][][]float64, 6), // Placeholder
+		Labels:   []int{0, 1, 0, 2, 1, 0},
+		Classes:  []string{"0", "1", "2"},
+		Width:    1,
+		Height:   1,
+		Channels: 1,
+	}
+
+	t.Run("ValidDistribution", func(t *testing.T) {
+		distribution := dataset.GetClassDistribution()
+
+		expected := map[int]int{
+			0: 3,
+			1: 2,
+			2: 1,
+		}
+
+		if !reflect.DeepEqual(distribution, expected) {
+			t.Errorf("Expected distribution %v, got %v", expected, distribution)
+		}
+	})
+
+	t.Run("EmptyLabels", func(t *testing.T) {
+		emptyDataset := &ImageDataset{
+			Name:     "Empty",
+			Images:   [][][][]float64{},
+			Labels:   []int{},
+			Classes:  []string{},
+			Width:    1,
+			Height:   1,
+			Channels: 1,
+		}
+
+		distribution := emptyDataset.GetClassDistribution()
+		if len(distribution) != 0 {
+			t.Errorf("Expected empty distribution for empty dataset, got %v", distribution)
+		}
+	})
+}
+
+// TestNormalization tests dataset normalization methods
+func TestNormalization(t *testing.T) {
+	// Create test dataset with known values for normalization testing
+	images := make([][][][]float64, 2)
+	labels := []int{0, 1}
+
+	// Image with values [0, 100, 200, 255] (simulating pixel values)
+	images[0] = make([][][]float64, 2)
+	images[0][0] = make([][]float64, 2)
+	images[0][0][0] = []float64{0}
+	images[0][0][1] = []float64{100}
+	images[0][1] = make([][]float64, 2)
+	images[0][1][0] = []float64{200}
+	images[0][1][1] = []float64{255}
+
+	// Second image with same pattern
+	images[1] = make([][][]float64, 2)
+	images[1][0] = make([][]float64, 2)
+	images[1][0][0] = []float64{0}
+	images[1][0][1] = []float64{100}
+	images[1][1] = make([][]float64, 2)
+	images[1][1][0] = []float64{200}
+	images[1][1][1] = []float64{255}
+
+	t.Run("MinMaxNormalization", func(t *testing.T) {
+		dataset := &ImageDataset{
+			Name:     "TestDataset",
+			Images:   copyImages(images), // Use copy to avoid modifying original
+			Labels:   labels,
+			Classes:  []string{"0", "1"},
+			Width:    2,
+			Height:   2,
+			Channels: 1,
+		}
+
+		err := dataset.NormalizeDataset("minmax")
+		if err != nil {
+			t.Fatalf("Normalization failed: %v", err)
+		}
+
+		// After min-max normalization: min=0 -> 0, max=255 -> 1
+		if dataset.Images[0][0][0][0] != 0.0 {
+			t.Errorf("Expected normalized min 0.0, got %f", dataset.Images[0][0][0][0])
+		}
+		if abs(dataset.Images[0][1][1][0]-1.0) > 1e-9 {
+			t.Errorf("Expected normalized max 1.0, got %f", dataset.Images[0][1][1][0])
+		}
+	})
+
+	t.Run("StandardNormalization", func(t *testing.T) {
+		dataset := &ImageDataset{
+			Name:     "TestDataset",
+			Images:   copyImages(images), // Use copy to avoid modifying original
+			Labels:   labels,
+			Classes:  []string{"0", "1"},
+			Width:    2,
+			Height:   2,
+			Channels: 1,
+		}
+
+		err := dataset.NormalizeDataset("standard")
+		if err != nil {
+			t.Fatalf("Normalization failed: %v", err)
+		}
+
+		// Verify that mean is approximately 0 after standardization
+		stats := dataset.GetImageStatistics()
+		if abs(stats["mean"]) > 1e-9 {
+			t.Errorf("Expected mean ~0 after standardization, got %f", stats["mean"])
+		}
+	})
+
+	t.Run("UnsupportedNormalization", func(t *testing.T) {
+		dataset := &ImageDataset{
+			Name:     "TestDataset",
+			Images:   copyImages(images),
+			Labels:   labels,
+			Classes:  []string{"0", "1"},
+			Width:    2,
+			Height:   2,
+			Channels: 1,
+		}
+
+		err := dataset.NormalizeDataset("unsupported")
+		if err == nil {
+			t.Error("Expected error for unsupported normalization method")
+		}
+	})
+
+	t.Run("EmptyDatasetNormalization", func(t *testing.T) {
+		emptyDataset := &ImageDataset{
+			Name:     "Empty",
+			Images:   [][][][]float64{},
+			Labels:   []int{},
+			Classes:  []string{},
+			Width:    1,
+			Height:   1,
+			Channels: 1,
+		}
+
+		err := emptyDataset.NormalizeDataset("standard")
+		if err == nil {
+			t.Error("Expected error for normalizing empty dataset")
+		}
+	})
+}
+
+// TestMNISTDataset tests MNIST-specific functionality
+func TestMNISTDataset(t *testing.T) {
+	t.Run("MNISTDatasetCreation", func(t *testing.T) {
+		// Create mock MNIST data
+		trainImages := make([][][][]float64, 2)
+		trainLabels := []int{0, 1}
+		testImages := make([][][][]float64, 1)
+		testLabels := []int{2}
+
+		// Initialize with 28x28x1 structure
+		for i := range trainImages {
+			trainImages[i] = make([][][]float64, 28)
+			for j := range trainImages[i] {
+				trainImages[i][j] = make([][]float64, 28)
+				for k := range trainImages[i][j] {
+					trainImages[i][j][k] = make([]float64, 1)
+					trainImages[i][j][k][0] = float64(i) // Simple test pattern
+				}
+			}
+		}
+
+		for i := range testImages {
+			testImages[i] = make([][][]float64, 28)
+			for j := range testImages[i] {
+				testImages[i][j] = make([][]float64, 28)
+				for k := range testImages[i][j] {
+					testImages[i][j][k] = make([]float64, 1)
+					testImages[i][j][k][0] = float64(i + 10) // Different pattern
+				}
+			}
+		}
+
+		mnist := &MNISTDataset{
+			TrainImages: trainImages,
+			TrainLabels: trainLabels,
+			TestImages:  testImages,
+			TestLabels:  testLabels,
+		}
+
+		// Test training dataset conversion
+		trainDataset := mnist.CreateDataset(false)
+		if trainDataset.Name != "MNIST" {
+			t.Errorf("Expected name 'MNIST', got %s", trainDataset.Name)
+		}
+		if len(trainDataset.Images) != 2 {
+			t.Errorf("Expected 2 training images, got %d", len(trainDataset.Images))
+		}
+		if trainDataset.Width != 28 || trainDataset.Height != 28 || trainDataset.Channels != 1 {
+			t.Errorf("Expected 28x28x1, got %dx%dx%d", trainDataset.Height, trainDataset.Width, trainDataset.Channels)
+		}
+
+		// Test test dataset conversion
+		testDataset := mnist.CreateDataset(true)
+		if len(testDataset.Images) != 1 {
+			t.Errorf("Expected 1 test image, got %d", len(testDataset.Images))
+		}
+	})
+}
+
+// TestPrintDatasetInfo tests the dataset info printing (basic functionality)
+func TestPrintDatasetInfo(t *testing.T) {
+	dataset := &ImageDataset{
+		Name:     "TestDataset",
+		Images:   make([][][][]float64, 5),
+		Labels:   []int{0, 1, 0, 1, 2},
+		Classes:  []string{"0", "1", "2"},
+		Width:    28,
+		Height:   28,
+		Channels: 1,
+	}
+
+	// Initialize images with placeholder data
+	for i := range dataset.Images {
+		dataset.Images[i] = make([][][]float64, 28)
+		for j := range dataset.Images[i] {
+			dataset.Images[i][j] = make([][]float64, 28)
+			for k := range dataset.Images[i][j] {
+				dataset.Images[i][j][k] = make([]float64, 1)
+				dataset.Images[i][j][k][0] = 0.5 // Constant value for simplicity
+			}
+		}
+	}
+
+	t.Run("PrintInfo", func(t *testing.T) {
+		// This test just ensures the function doesn't panic
+		// In a real scenario, you might capture stdout to verify output
+		dataset.PrintDatasetInfo()
+	})
+}
+
+// Helper functions for testing
+
+// copyImages creates a deep copy of images array for testing
+func copyImages(original [][][][]float64) [][][][]float64 {
+	copy := make([][][][]float64, len(original))
+	for i := range original {
+		copy[i] = make([][][]float64, len(original[i]))
+		for j := range original[i] {
+			copy[i][j] = make([][]float64, len(original[i][j]))
+			for k := range original[i][j] {
+				copy[i][j][k] = make([]float64, len(original[i][j][k]))
+				for l := range original[i][j][k] {
+					copy[i][j][k][l] = original[i][j][k][l]
+				}
+			}
+		}
+	}
+	return copy
+}
+
+// abs returns the absolute value of a float64
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// TestEdgeCases tests various edge cases and error conditions
+func TestEdgeCases(t *testing.T) {
+	t.Run("LoadMNISTInvalidDirectory", func(t *testing.T) {
+		// Test with non-existent directory that we can't create (permission test)
+		_, err := LoadMNIST("/invalid/read/only/path")
+		if err == nil {
+			t.Error("Expected error for invalid directory path")
+		}
+	})
+
+	t.Run("GetBatchSingleIndex", func(t *testing.T) {
+		// Create minimal dataset
+		images := make([][][][]float64, 1)
+		images[0] = make([][][]float64, 1)
+		images[0][0] = make([][]float64, 1)
+		images[0][0][0] = []float64{0.5}
+
+		dataset := &ImageDataset{
+			Name:     "SingleImage",
+			Images:   images,
+			Labels:   []int{0},
+			Classes:  []string{"0"},
+			Width:    1,
+			Height:   1,
+			Channels: 1,
+		}
+
+		batchImages, batchLabels, err := dataset.GetBatch([]int{0})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(batchImages) != 1 || len(batchLabels) != 1 {
+			t.Errorf("Expected batch size 1, got images: %d, labels: %d", len(batchImages), len(batchLabels))
+		}
+	})
+
+	t.Run("NormalizationZeroVariance", func(t *testing.T) {
+		// Create dataset with constant pixel values
+		images := make([][][][]float64, 2)
+		for i := range images {
+			images[i] = make([][][]float64, 2)
+			for j := range images[i] {
+				images[i][j] = make([][]float64, 2)
+				for k := range images[i][j] {
+					images[i][j][k] = []float64{0.5} // All pixels same value
+				}
+			}
+		}
+
+		dataset := &ImageDataset{
+			Name:     "ConstantDataset",
+			Images:   images,
+			Labels:   []int{0, 1},
+			Classes:  []string{"0", "1"},
+			Width:    2,
+			Height:   2,
+			Channels: 1,
+		}
+
+		err := dataset.NormalizeDataset("standard")
+		if err == nil {
+			t.Error("Expected error for zero variance in standard normalization")
+		}
+	})
+
+	t.Run("NormalizationZeroRange", func(t *testing.T) {
+		// Create dataset with constant pixel values for min-max test
+		images := make([][][][]float64, 1)
+		images[0] = make([][][]float64, 1)
+		images[0][0] = make([][]float64, 1)
+		images[0][0][0] = []float64{0.5}
+
+		dataset := &ImageDataset{
+			Name:     "ConstantDataset",
+			Images:   images,
+			Labels:   []int{0},
+			Classes:  []string{"0"},
+			Width:    1,
+			Height:   1,
+			Channels: 1,
+		}
+
+		err := dataset.NormalizeDataset("minmax")
+		if err == nil {
+			t.Error("Expected error for zero range in minmax normalization")
+		}
+	})
+}
+
+// TestMNISTIntegration tests MNIST loading integration (requires internet)
+func TestMNISTIntegration(t *testing.T) {
+	// This test is marked as integration and may be skipped in CI
+	if testing.Short() {
+		t.Skip("Skipping MNIST integration test in short mode")
+	}
+
+	t.Run("LoadMNISTWithTempDir", func(t *testing.T) {
+		// Create temporary directory for test
+		tempDir := t.TempDir()
+
+		// Note: This test will actually download MNIST data if not cached
+		// In a real scenario, you might want to use mock data or check if internet is available
+		mnist, err := LoadMNIST(tempDir)
+		if err != nil {
+			t.Skipf("Skipping MNIST test due to download failure: %v", err)
+			return
+		}
+
+		// Verify dataset structure
+		if len(mnist.TrainImages) == 0 {
+			t.Error("Expected non-empty training images")
+		}
+		if len(mnist.TrainLabels) == 0 {
+			t.Error("Expected non-empty training labels")
+		}
+		if len(mnist.TestImages) == 0 {
+			t.Error("Expected non-empty test images")
+		}
+		if len(mnist.TestLabels) == 0 {
+			t.Error("Expected non-empty test labels")
+		}
+
+		// Verify image dimensions
+		if len(mnist.TrainImages) > 0 {
+			if len(mnist.TrainImages[0]) != 28 {
+				t.Errorf("Expected height 28, got %d", len(mnist.TrainImages[0]))
+			}
+			if len(mnist.TrainImages[0][0]) != 28 {
+				t.Errorf("Expected width 28, got %d", len(mnist.TrainImages[0][0]))
+			}
+			if len(mnist.TrainImages[0][0][0]) != 1 {
+				t.Errorf("Expected 1 channel, got %d", len(mnist.TrainImages[0][0][0]))
+			}
+		}
+
+		// Test conversion to dataset format
+		trainDataset := mnist.CreateDataset(false)
+		testDataset := mnist.CreateDataset(true)
+
+		trainDataset.PrintDatasetInfo()
+		testDataset.PrintDatasetInfo()
+	})
+}

--- a/phase2/cnn.go
+++ b/phase2/cnn.go
@@ -9,6 +9,12 @@ import (
 	"math/rand"
 )
 
+// RandNormal returns a random number from standard normal distribution
+// Learning Goal: Understanding random initialization patterns
+func RandNormal() float64 {
+	return rand.NormFloat64() //nolint:gosec // Educational implementation, cryptographic randomness not required
+}
+
 // ActivationFunction represents different activation functions for CNN layers
 type ActivationFunction int
 


### PR DESCRIPTION
## 概要

Issue #52のPhase 2.2: 画像データセット対応を実装。MNIST/CIFAR-10データセットの統合により、CNN性能評価が可能になりました。

## 変更内容

### 主要な新機能
- **MNIST バイナリデータローダー**: IDX3/IDX1形式の完全対応
- **画像前処理パイプライン**: 正規化、統計計算、バッチ処理
- **CNN評価フレームワーク**: 訓練・テスト・性能測定の統合システム
- **CLI統合**: `bee mnist` コマンドによるデモンストレーション

### 実装ファイル
- `datasets/image.go` - 画像データセット実装 (454行)
- `datasets/image_test.go` - 包括的テストスイート (704行)
- `datasets/cnn_eval.go` - CNN評価フレームワーク (505行)
- `datasets/cnn_eval_test.go` - CNN評価テスト (649行)
- `cmd/bee/mnist_example.go` - MNIST CNNデモ (157行)
- `cmd/bee/main.go` - CLI統合
- `phase2/cnn.go` - RandNormal()ヘルパー関数追加

### 技術的改善
- クロスエントロピー損失とソフトマックス活性化関数の実装
- Xavier重み初期化によるCNN完全結合層の最適化
- メモリ使用量推定と推論時間測定
- エラーハンドリングと数値安定性の向上

## テスト

### テストカバレッジ
- **29+個のテストケース**: 全機能をカバー
- **統合テスト**: MNIST実データでの動作確認
- **エッジケースハンドリング**: 空データセット、エラー条件等

### 品質チェック
- ✅ `make quality` - 全品質チェック通過
- ✅ フォーマット・リント・型チェック完了
- ✅ 包括的テストスイート実行成功

### 実行方法
```bash
# MNIST CNN デモンストレーション
bee mnist --data-dir ./datasets/mnist --verbose

# 品質チェック実行
make quality

# テスト実行
make test
```

## 学習効果

この実装により以下の学習目標を達成：

1. **画像データ処理**: バイナリ形式解析、前処理パイプライン
2. **CNN評価手法**: 訓練ループ、損失計算、精度評価
3. **性能測定技術**: メモリ使用量、推論時間の計測
4. **実践的ML手法**: データシャッフル、バッチ処理、正規化

Closes #52